### PR TITLE
Implemented WithSchemaPath() allowing alternative schema locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,24 @@ func (Character) Annotations() []schema.Annotation {
 	}
 }
 ```
+### Setting a schema path
+To allow setting an alternative schema location other than `ent/schema` you can supply the `enthistory.NewExtension()` function with 
+the `enthistory.WithUpdatedBy()` Option. You choose your schema path (string) which should be the same as the schema path set in the `entc.Generate` function
+otherwise the extension will be unable to locate the schemas. You can leave the `enthistory.WithUpdatedBy()` function entirely if you don't plan on setting an alternative
+schema location than `ent/schema`.
 
+```go
+func main() {
+	entc.Generate("./schema2",
+		&gen.Config{},
+		entc.Extensions(
+			enthistory.NewHistoryExtension(
+				enthistory.WithSchemaPath("./schema2")
+			),
+		),
+	)
+}
+```
 
 ## Caveats
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/flume/enthistory
+module github.com/matthewbehnke/enthistory
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/matthewbehnke/enthistory
+module github.com/flume/enthistory
 
 go 1.19
 

--- a/utils.go
+++ b/utils.go
@@ -1,8 +1,6 @@
 package enthistory
 
 import (
-	"fmt"
-	"os"
 	"regexp"
 	"strings"
 
@@ -65,30 +63,6 @@ func createHistoryFields(schemaFields []*load.Field) []*load.Field {
 		historyFields[j] = &newField
 	}
 	return historyFields
-}
-
-func getHistorySchemaPath(schema *load.Schema) (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	path := fmt.Sprintf("%v/schema/%v.go", dir, fmt.Sprintf("%s_history", strings.ToLower(schema.Name)))
-	return path, nil
-}
-
-func removeOldGenerated(schemas []*load.Schema) error {
-	for _, schema := range schemas {
-		path, err := getHistorySchemaPath(schema)
-		if err != nil {
-			return err
-		}
-
-		err = os.RemoveAll(path)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func loadHistorySchema() (*load.Schema, error) {


### PR DESCRIPTION
## Description
I added WithSchemaPath() to the ExtensionOption type to allow alternate schema locations to be used. 
When WithSchemaPath() option is used it sets a SchemaPath option on the config type. Allowing when the HistoryExtension is created a schema location to be set so when getHistorySchemaPath() is called it will return the correct schema location.

## Motivation and Context
This change is required to allow alternate schema location to be set following entc Generate() behavior  allowing more usages of ent to use the enthistory extension. 

https://github.com/flume/enthistory/issues/7

## How Has This Been Tested?

I could not think of a good way to write a test case for setting an alternative schema location other than having another 
ent database in the _examples folder. To verify I changed all the occurrences of ent/schema to ent/schema2 and the set WithSchemaPath("./schema2") and changed entc.Generate("./schema2",.... ) then generated the ent code. Once the code was generated I ran all the tests to verify everything worked as expected. 

Please let me know if you would like an example under _examples.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update or addition to documentation for this project)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
