### PR TITLE
Fixed a bug where duplicate schema initials caused invalid code generation

### DIFF
--- a/_examples/basic/ent/auditing.go
+++ b/_examples/basic/ent/auditing.go
@@ -156,17 +156,19 @@ func (c *Client) Audit(ctx context.Context) ([][]string, error) {
 	records := [][]string{
 		{"Table", "Ref Id", "History Time", "Operation", "Changes", "Updated By"},
 	}
-	chRecords, err := auditCharacterHistory(ctx, c.config)
+	var record [][]string
+	var err error
+	record, err = auditCharacterHistory(ctx, c.config)
 	if err != nil {
 		return nil, err
 	}
-	records = append(records, chRecords...)
+	records = append(records, record...)
 
-	fhRecords, err := auditFriendshipHistory(ctx, c.config)
+	record, err = auditFriendshipHistory(ctx, c.config)
 	if err != nil {
 		return nil, err
 	}
-	records = append(records, fhRecords...)
+	records = append(records, record...)
 
 	return records, nil
 }

--- a/templates/auditing.tmpl
+++ b/templates/auditing.tmpl
@@ -139,13 +139,16 @@ func (c *Client) Audit(ctx context.Context) ([][]string, error) {
 	records := [][]string{
 		{"Table", "Ref Id", "History Time", "Operation", "Changes"{{ if not (eq $updatedByKey "") }}, "Updated By" {{ end }}},
 	}
+	var record [][]string
+	var err error
+	
 	{{- range $n := $.Nodes }}
     {{- if (hasSuffix $n.Name "History") }}
-	{{ $n.Receiver }}Records, err := audit{{ $n.Name }}(ctx, c.config)
+	record, err = audit{{ $n.Name }}(ctx, c.config)
 	if err != nil {
 		return nil, err
 	}
-	records = append(records, {{ $n.Receiver }}Records...)
+	records = append(records, record...)
     {{ end }}
 	{{- end }}
 


### PR DESCRIPTION
## Description

When two Schemas had the name initials like Company and Client for example. The audit template would create a new variable name with the initials of the schemas. When incorporating enthistory into a project I found this to be an issue so  I fixed this by declaring the variable once and then reusing it throughout the method

## Motivation and Context
The template would generate invalid go code when two Schemas had the name initials like Company and Client

## How Has This Been Tested?
I'm not sure the best way to test this fix. Logically the existing tests cover the auditing functionality so its already tested.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update or addition to documentation for this project)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
