### PR TITLE
Allow Many types for ID (string & int for now)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 # vendor/
 .DS_STORE
 .idea
+entdb

--- a/_examples/basic/ent/auditing.go
+++ b/_examples/basic/ent/auditing.go
@@ -204,7 +204,7 @@ func (c *Client) Audit(ctx context.Context) ([][]string, error) {
 
 type record struct {
 	Table       string
-	RefId       int
+	RefId       any
 	HistoryTime time.Time
 	Operation   enthistory.OpType
 	Changes     []Change
@@ -231,13 +231,13 @@ func (r *record) toRow() []string {
 	return row
 }
 
-type ref struct {
+type characterhistoryref struct {
 	Ref int
 }
 
 func auditCharacterHistory(ctx context.Context, config config) ([][]string, error) {
 	var records = [][]string{}
-	var refs []ref
+	var refs []characterhistoryref
 	client := NewCharacterHistoryClient(config)
 	err := client.Query().
 		Unique(true).
@@ -283,9 +283,14 @@ func auditCharacterHistory(ctx context.Context, config config) ([][]string, erro
 	}
 	return records, nil
 }
+
+type friendshiphistoryref struct {
+	Ref string
+}
+
 func auditFriendshipHistory(ctx context.Context, config config) ([][]string, error) {
 	var records = [][]string{}
-	var refs []ref
+	var refs []friendshiphistoryref
 	client := NewFriendshipHistoryClient(config)
 	err := client.Query().
 		Unique(true).

--- a/_examples/basic/ent/character_create.go
+++ b/_examples/basic/ent/character_create.go
@@ -78,14 +78,14 @@ func (cc *CharacterCreate) AddFriends(c ...*Character) *CharacterCreate {
 }
 
 // AddFriendshipIDs adds the "friendships" edge to the Friendship entity by IDs.
-func (cc *CharacterCreate) AddFriendshipIDs(ids ...int) *CharacterCreate {
+func (cc *CharacterCreate) AddFriendshipIDs(ids ...string) *CharacterCreate {
 	cc.mutation.AddFriendshipIDs(ids...)
 	return cc
 }
 
 // AddFriendships adds the "friendships" edges to the Friendship entity.
 func (cc *CharacterCreate) AddFriendships(f ...*Friendship) *CharacterCreate {
-	ids := make([]int, len(f))
+	ids := make([]string, len(f))
 	for i := range f {
 		ids[i] = f[i].ID
 	}
@@ -226,7 +226,7 @@ func (cc *CharacterCreate) createSpec() (*Character, *sqlgraph.CreateSpec) {
 			Columns: []string{character.FriendshipsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/_examples/basic/ent/character_update.go
+++ b/_examples/basic/ent/character_update.go
@@ -79,14 +79,14 @@ func (cu *CharacterUpdate) AddFriends(c ...*Character) *CharacterUpdate {
 }
 
 // AddFriendshipIDs adds the "friendships" edge to the Friendship entity by IDs.
-func (cu *CharacterUpdate) AddFriendshipIDs(ids ...int) *CharacterUpdate {
+func (cu *CharacterUpdate) AddFriendshipIDs(ids ...string) *CharacterUpdate {
 	cu.mutation.AddFriendshipIDs(ids...)
 	return cu
 }
 
 // AddFriendships adds the "friendships" edges to the Friendship entity.
 func (cu *CharacterUpdate) AddFriendships(f ...*Friendship) *CharacterUpdate {
-	ids := make([]int, len(f))
+	ids := make([]string, len(f))
 	for i := range f {
 		ids[i] = f[i].ID
 	}
@@ -126,14 +126,14 @@ func (cu *CharacterUpdate) ClearFriendships() *CharacterUpdate {
 }
 
 // RemoveFriendshipIDs removes the "friendships" edge to Friendship entities by IDs.
-func (cu *CharacterUpdate) RemoveFriendshipIDs(ids ...int) *CharacterUpdate {
+func (cu *CharacterUpdate) RemoveFriendshipIDs(ids ...string) *CharacterUpdate {
 	cu.mutation.RemoveFriendshipIDs(ids...)
 	return cu
 }
 
 // RemoveFriendships removes "friendships" edges to Friendship entities.
 func (cu *CharacterUpdate) RemoveFriendships(f ...*Friendship) *CharacterUpdate {
-	ids := make([]int, len(f))
+	ids := make([]string, len(f))
 	for i := range f {
 		ids[i] = f[i].ID
 	}
@@ -266,7 +266,7 @@ func (cu *CharacterUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{character.FriendshipsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeString),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -279,7 +279,7 @@ func (cu *CharacterUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{character.FriendshipsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {
@@ -295,7 +295,7 @@ func (cu *CharacterUpdate) sqlSave(ctx context.Context) (n int, err error) {
 			Columns: []string{character.FriendshipsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {
@@ -372,14 +372,14 @@ func (cuo *CharacterUpdateOne) AddFriends(c ...*Character) *CharacterUpdateOne {
 }
 
 // AddFriendshipIDs adds the "friendships" edge to the Friendship entity by IDs.
-func (cuo *CharacterUpdateOne) AddFriendshipIDs(ids ...int) *CharacterUpdateOne {
+func (cuo *CharacterUpdateOne) AddFriendshipIDs(ids ...string) *CharacterUpdateOne {
 	cuo.mutation.AddFriendshipIDs(ids...)
 	return cuo
 }
 
 // AddFriendships adds the "friendships" edges to the Friendship entity.
 func (cuo *CharacterUpdateOne) AddFriendships(f ...*Friendship) *CharacterUpdateOne {
-	ids := make([]int, len(f))
+	ids := make([]string, len(f))
 	for i := range f {
 		ids[i] = f[i].ID
 	}
@@ -419,14 +419,14 @@ func (cuo *CharacterUpdateOne) ClearFriendships() *CharacterUpdateOne {
 }
 
 // RemoveFriendshipIDs removes the "friendships" edge to Friendship entities by IDs.
-func (cuo *CharacterUpdateOne) RemoveFriendshipIDs(ids ...int) *CharacterUpdateOne {
+func (cuo *CharacterUpdateOne) RemoveFriendshipIDs(ids ...string) *CharacterUpdateOne {
 	cuo.mutation.RemoveFriendshipIDs(ids...)
 	return cuo
 }
 
 // RemoveFriendships removes "friendships" edges to Friendship entities.
 func (cuo *CharacterUpdateOne) RemoveFriendships(f ...*Friendship) *CharacterUpdateOne {
-	ids := make([]int, len(f))
+	ids := make([]string, len(f))
 	for i := range f {
 		ids[i] = f[i].ID
 	}
@@ -589,7 +589,7 @@ func (cuo *CharacterUpdateOne) sqlSave(ctx context.Context) (_node *Character, e
 			Columns: []string{character.FriendshipsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeString),
 			},
 		}
 		_spec.Edges.Clear = append(_spec.Edges.Clear, edge)
@@ -602,7 +602,7 @@ func (cuo *CharacterUpdateOne) sqlSave(ctx context.Context) (_node *Character, e
 			Columns: []string{character.FriendshipsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {
@@ -618,7 +618,7 @@ func (cuo *CharacterUpdateOne) sqlSave(ctx context.Context) (_node *Character, e
 			Columns: []string{character.FriendshipsColumn},
 			Bidi:    false,
 			Target: &sqlgraph.EdgeTarget{
-				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeInt),
+				IDSpec: sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeString),
 			},
 		}
 		for _, k := range nodes {

--- a/_examples/basic/ent/characterhistory.go
+++ b/_examples/basic/ent/characterhistory.go
@@ -21,10 +21,10 @@ type CharacterHistory struct {
 	ID int `json:"id,omitempty"`
 	// HistoryTime holds the value of the "history_time" field.
 	HistoryTime time.Time `json:"history_time,omitempty"`
-	// Ref holds the value of the "ref" field.
-	Ref int `json:"ref,omitempty"`
 	// Operation holds the value of the "operation" field.
 	Operation enthistory.OpType `json:"operation,omitempty"`
+	// Ref holds the value of the "ref" field.
+	Ref int `json:"ref,omitempty"`
 	// UpdatedBy holds the value of the "updated_by" field.
 	UpdatedBy *int `json:"updated_by,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
@@ -76,17 +76,17 @@ func (ch *CharacterHistory) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				ch.HistoryTime = value.Time
 			}
-		case characterhistory.FieldRef:
-			if value, ok := values[i].(*sql.NullInt64); !ok {
-				return fmt.Errorf("unexpected type %T for field ref", values[i])
-			} else if value.Valid {
-				ch.Ref = int(value.Int64)
-			}
 		case characterhistory.FieldOperation:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field operation", values[i])
 			} else if value.Valid {
 				ch.Operation = enthistory.OpType(value.String)
+			}
+		case characterhistory.FieldRef:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field ref", values[i])
+			} else if value.Valid {
+				ch.Ref = int(value.Int64)
 			}
 		case characterhistory.FieldUpdatedBy:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -158,11 +158,11 @@ func (ch *CharacterHistory) String() string {
 	builder.WriteString("history_time=")
 	builder.WriteString(ch.HistoryTime.Format(time.ANSIC))
 	builder.WriteString(", ")
-	builder.WriteString("ref=")
-	builder.WriteString(fmt.Sprintf("%v", ch.Ref))
-	builder.WriteString(", ")
 	builder.WriteString("operation=")
 	builder.WriteString(fmt.Sprintf("%v", ch.Operation))
+	builder.WriteString(", ")
+	builder.WriteString("ref=")
+	builder.WriteString(fmt.Sprintf("%v", ch.Ref))
 	builder.WriteString(", ")
 	if v := ch.UpdatedBy; v != nil {
 		builder.WriteString("updated_by=")

--- a/_examples/basic/ent/characterhistory/characterhistory.go
+++ b/_examples/basic/ent/characterhistory/characterhistory.go
@@ -18,10 +18,10 @@ const (
 	FieldID = "id"
 	// FieldHistoryTime holds the string denoting the history_time field in the database.
 	FieldHistoryTime = "history_time"
-	// FieldRef holds the string denoting the ref field in the database.
-	FieldRef = "ref"
 	// FieldOperation holds the string denoting the operation field in the database.
 	FieldOperation = "operation"
+	// FieldRef holds the string denoting the ref field in the database.
+	FieldRef = "ref"
 	// FieldUpdatedBy holds the string denoting the updated_by field in the database.
 	FieldUpdatedBy = "updated_by"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
@@ -40,8 +40,8 @@ const (
 var Columns = []string{
 	FieldID,
 	FieldHistoryTime,
-	FieldRef,
 	FieldOperation,
+	FieldRef,
 	FieldUpdatedBy,
 	FieldCreatedAt,
 	FieldUpdatedAt,
@@ -93,14 +93,14 @@ func ByHistoryTime(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldHistoryTime, opts...).ToFunc()
 }
 
-// ByRef orders the results by the ref field.
-func ByRef(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldRef, opts...).ToFunc()
-}
-
 // ByOperation orders the results by the operation field.
 func ByOperation(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOperation, opts...).ToFunc()
+}
+
+// ByRef orders the results by the ref field.
+func ByRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRef, opts...).ToFunc()
 }
 
 // ByUpdatedBy orders the results by the updated_by field.

--- a/_examples/basic/ent/characterhistory/where.go
+++ b/_examples/basic/ent/characterhistory/where.go
@@ -131,6 +131,26 @@ func HistoryTimeLTE(v time.Time) predicate.CharacterHistory {
 	return predicate.CharacterHistory(sql.FieldLTE(FieldHistoryTime, v))
 }
 
+// OperationEQ applies the EQ predicate on the "operation" field.
+func OperationEQ(v enthistory.OpType) predicate.CharacterHistory {
+	return predicate.CharacterHistory(sql.FieldEQ(FieldOperation, v))
+}
+
+// OperationNEQ applies the NEQ predicate on the "operation" field.
+func OperationNEQ(v enthistory.OpType) predicate.CharacterHistory {
+	return predicate.CharacterHistory(sql.FieldNEQ(FieldOperation, v))
+}
+
+// OperationIn applies the In predicate on the "operation" field.
+func OperationIn(vs ...enthistory.OpType) predicate.CharacterHistory {
+	return predicate.CharacterHistory(sql.FieldIn(FieldOperation, vs...))
+}
+
+// OperationNotIn applies the NotIn predicate on the "operation" field.
+func OperationNotIn(vs ...enthistory.OpType) predicate.CharacterHistory {
+	return predicate.CharacterHistory(sql.FieldNotIn(FieldOperation, vs...))
+}
+
 // RefEQ applies the EQ predicate on the "ref" field.
 func RefEQ(v int) predicate.CharacterHistory {
 	return predicate.CharacterHistory(sql.FieldEQ(FieldRef, v))
@@ -179,26 +199,6 @@ func RefIsNil() predicate.CharacterHistory {
 // RefNotNil applies the NotNil predicate on the "ref" field.
 func RefNotNil() predicate.CharacterHistory {
 	return predicate.CharacterHistory(sql.FieldNotNull(FieldRef))
-}
-
-// OperationEQ applies the EQ predicate on the "operation" field.
-func OperationEQ(v enthistory.OpType) predicate.CharacterHistory {
-	return predicate.CharacterHistory(sql.FieldEQ(FieldOperation, v))
-}
-
-// OperationNEQ applies the NEQ predicate on the "operation" field.
-func OperationNEQ(v enthistory.OpType) predicate.CharacterHistory {
-	return predicate.CharacterHistory(sql.FieldNEQ(FieldOperation, v))
-}
-
-// OperationIn applies the In predicate on the "operation" field.
-func OperationIn(vs ...enthistory.OpType) predicate.CharacterHistory {
-	return predicate.CharacterHistory(sql.FieldIn(FieldOperation, vs...))
-}
-
-// OperationNotIn applies the NotIn predicate on the "operation" field.
-func OperationNotIn(vs ...enthistory.OpType) predicate.CharacterHistory {
-	return predicate.CharacterHistory(sql.FieldNotIn(FieldOperation, vs...))
 }
 
 // UpdatedByEQ applies the EQ predicate on the "updated_by" field.

--- a/_examples/basic/ent/characterhistory_create.go
+++ b/_examples/basic/ent/characterhistory_create.go
@@ -36,6 +36,12 @@ func (chc *CharacterHistoryCreate) SetNillableHistoryTime(t *time.Time) *Charact
 	return chc
 }
 
+// SetOperation sets the "operation" field.
+func (chc *CharacterHistoryCreate) SetOperation(et enthistory.OpType) *CharacterHistoryCreate {
+	chc.mutation.SetOperation(et)
+	return chc
+}
+
 // SetRef sets the "ref" field.
 func (chc *CharacterHistoryCreate) SetRef(i int) *CharacterHistoryCreate {
 	chc.mutation.SetRef(i)
@@ -47,12 +53,6 @@ func (chc *CharacterHistoryCreate) SetNillableRef(i *int) *CharacterHistoryCreat
 	if i != nil {
 		chc.SetRef(*i)
 	}
-	return chc
-}
-
-// SetOperation sets the "operation" field.
-func (chc *CharacterHistoryCreate) SetOperation(et enthistory.OpType) *CharacterHistoryCreate {
-	chc.mutation.SetOperation(et)
 	return chc
 }
 
@@ -219,13 +219,13 @@ func (chc *CharacterHistoryCreate) createSpec() (*CharacterHistory, *sqlgraph.Cr
 		_spec.SetField(characterhistory.FieldHistoryTime, field.TypeTime, value)
 		_node.HistoryTime = value
 	}
-	if value, ok := chc.mutation.Ref(); ok {
-		_spec.SetField(characterhistory.FieldRef, field.TypeInt, value)
-		_node.Ref = value
-	}
 	if value, ok := chc.mutation.Operation(); ok {
 		_spec.SetField(characterhistory.FieldOperation, field.TypeEnum, value)
 		_node.Operation = value
+	}
+	if value, ok := chc.mutation.Ref(); ok {
+		_spec.SetField(characterhistory.FieldRef, field.TypeInt, value)
+		_node.Ref = value
 	}
 	if value, ok := chc.mutation.UpdatedBy(); ok {
 		_spec.SetField(characterhistory.FieldUpdatedBy, field.TypeInt, value)

--- a/_examples/basic/ent/client.go
+++ b/_examples/basic/ent/client.go
@@ -549,7 +549,7 @@ func (c *FriendshipClient) UpdateOne(f *Friendship) *FriendshipUpdateOne {
 }
 
 // UpdateOneID returns an update builder for the given id.
-func (c *FriendshipClient) UpdateOneID(id int) *FriendshipUpdateOne {
+func (c *FriendshipClient) UpdateOneID(id string) *FriendshipUpdateOne {
 	mutation := newFriendshipMutation(c.config, OpUpdateOne, withFriendshipID(id))
 	return &FriendshipUpdateOne{config: c.config, hooks: c.Hooks(), mutation: mutation}
 }
@@ -566,7 +566,7 @@ func (c *FriendshipClient) DeleteOne(f *Friendship) *FriendshipDeleteOne {
 }
 
 // DeleteOneID returns a builder for deleting the given entity by its id.
-func (c *FriendshipClient) DeleteOneID(id int) *FriendshipDeleteOne {
+func (c *FriendshipClient) DeleteOneID(id string) *FriendshipDeleteOne {
 	builder := c.Delete().Where(friendship.ID(id))
 	builder.mutation.id = &id
 	builder.mutation.op = OpDeleteOne
@@ -583,12 +583,12 @@ func (c *FriendshipClient) Query() *FriendshipQuery {
 }
 
 // Get returns a Friendship entity by its id.
-func (c *FriendshipClient) Get(ctx context.Context, id int) (*Friendship, error) {
+func (c *FriendshipClient) Get(ctx context.Context, id string) (*Friendship, error) {
 	return c.Query().Where(friendship.ID(id)).Only(ctx)
 }
 
 // GetX is like Get, but panics if an error occurs.
-func (c *FriendshipClient) GetX(ctx context.Context, id int) *Friendship {
+func (c *FriendshipClient) GetX(ctx context.Context, id string) *Friendship {
 	obj, err := c.Get(ctx, id)
 	if err != nil {
 		panic(err)

--- a/_examples/basic/ent/friendship.go
+++ b/_examples/basic/ent/friendship.go
@@ -18,7 +18,7 @@ import (
 type Friendship struct {
 	config `json:"-"`
 	// ID of the ent.
-	ID int `json:"id,omitempty"`
+	ID string `json:"id,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
 	CreatedAt time.Time `json:"created_at,omitempty"`
 	// UpdatedAt holds the value of the "updated_at" field.
@@ -75,8 +75,10 @@ func (*Friendship) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case friendship.FieldID, friendship.FieldCharacterID, friendship.FieldFriendID:
+		case friendship.FieldCharacterID, friendship.FieldFriendID:
 			values[i] = new(sql.NullInt64)
+		case friendship.FieldID:
+			values[i] = new(sql.NullString)
 		case friendship.FieldCreatedAt, friendship.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
 		default:
@@ -95,11 +97,11 @@ func (f *Friendship) assignValues(columns []string, values []any) error {
 	for i := range columns {
 		switch columns[i] {
 		case friendship.FieldID:
-			value, ok := values[i].(*sql.NullInt64)
-			if !ok {
-				return fmt.Errorf("unexpected type %T for field id", value)
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field id", values[i])
+			} else if value.Valid {
+				f.ID = value.String
 			}
-			f.ID = int(value.Int64)
 		case friendship.FieldCreatedAt:
 			if value, ok := values[i].(*sql.NullTime); !ok {
 				return fmt.Errorf("unexpected type %T for field created_at", values[i])

--- a/_examples/basic/ent/friendship/where.go
+++ b/_examples/basic/ent/friendship/where.go
@@ -12,48 +12,58 @@ import (
 )
 
 // ID filters vertices based on their ID field.
-func ID(id int) predicate.Friendship {
+func ID(id string) predicate.Friendship {
 	return predicate.Friendship(sql.FieldEQ(FieldID, id))
 }
 
 // IDEQ applies the EQ predicate on the ID field.
-func IDEQ(id int) predicate.Friendship {
+func IDEQ(id string) predicate.Friendship {
 	return predicate.Friendship(sql.FieldEQ(FieldID, id))
 }
 
 // IDNEQ applies the NEQ predicate on the ID field.
-func IDNEQ(id int) predicate.Friendship {
+func IDNEQ(id string) predicate.Friendship {
 	return predicate.Friendship(sql.FieldNEQ(FieldID, id))
 }
 
 // IDIn applies the In predicate on the ID field.
-func IDIn(ids ...int) predicate.Friendship {
+func IDIn(ids ...string) predicate.Friendship {
 	return predicate.Friendship(sql.FieldIn(FieldID, ids...))
 }
 
 // IDNotIn applies the NotIn predicate on the ID field.
-func IDNotIn(ids ...int) predicate.Friendship {
+func IDNotIn(ids ...string) predicate.Friendship {
 	return predicate.Friendship(sql.FieldNotIn(FieldID, ids...))
 }
 
 // IDGT applies the GT predicate on the ID field.
-func IDGT(id int) predicate.Friendship {
+func IDGT(id string) predicate.Friendship {
 	return predicate.Friendship(sql.FieldGT(FieldID, id))
 }
 
 // IDGTE applies the GTE predicate on the ID field.
-func IDGTE(id int) predicate.Friendship {
+func IDGTE(id string) predicate.Friendship {
 	return predicate.Friendship(sql.FieldGTE(FieldID, id))
 }
 
 // IDLT applies the LT predicate on the ID field.
-func IDLT(id int) predicate.Friendship {
+func IDLT(id string) predicate.Friendship {
 	return predicate.Friendship(sql.FieldLT(FieldID, id))
 }
 
 // IDLTE applies the LTE predicate on the ID field.
-func IDLTE(id int) predicate.Friendship {
+func IDLTE(id string) predicate.Friendship {
 	return predicate.Friendship(sql.FieldLTE(FieldID, id))
+}
+
+// IDEqualFold applies the EqualFold predicate on the ID field.
+func IDEqualFold(id string) predicate.Friendship {
+	return predicate.Friendship(sql.FieldEqualFold(FieldID, id))
+}
+
+// IDContainsFold applies the ContainsFold predicate on the ID field.
+func IDContainsFold(id string) predicate.Friendship {
+	return predicate.Friendship(sql.FieldContainsFold(FieldID, id))
 }
 
 // CreatedAt applies equality check predicate on the "created_at" field. It's identical to CreatedAtEQ.

--- a/_examples/basic/ent/friendship_delete.go
+++ b/_examples/basic/ent/friendship_delete.go
@@ -41,7 +41,7 @@ func (fd *FriendshipDelete) ExecX(ctx context.Context) int {
 }
 
 func (fd *FriendshipDelete) sqlExec(ctx context.Context) (int, error) {
-	_spec := sqlgraph.NewDeleteSpec(friendship.Table, sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewDeleteSpec(friendship.Table, sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeString))
 	if ps := fd.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {

--- a/_examples/basic/ent/friendship_query.go
+++ b/_examples/basic/ent/friendship_query.go
@@ -129,8 +129,8 @@ func (fq *FriendshipQuery) FirstX(ctx context.Context) *Friendship {
 
 // FirstID returns the first Friendship ID from the query.
 // Returns a *NotFoundError when no Friendship ID was found.
-func (fq *FriendshipQuery) FirstID(ctx context.Context) (id int, err error) {
-	var ids []int
+func (fq *FriendshipQuery) FirstID(ctx context.Context) (id string, err error) {
+	var ids []string
 	if ids, err = fq.Limit(1).IDs(setContextOp(ctx, fq.ctx, "FirstID")); err != nil {
 		return
 	}
@@ -142,7 +142,7 @@ func (fq *FriendshipQuery) FirstID(ctx context.Context) (id int, err error) {
 }
 
 // FirstIDX is like FirstID, but panics if an error occurs.
-func (fq *FriendshipQuery) FirstIDX(ctx context.Context) int {
+func (fq *FriendshipQuery) FirstIDX(ctx context.Context) string {
 	id, err := fq.FirstID(ctx)
 	if err != nil && !IsNotFound(err) {
 		panic(err)
@@ -180,8 +180,8 @@ func (fq *FriendshipQuery) OnlyX(ctx context.Context) *Friendship {
 // OnlyID is like Only, but returns the only Friendship ID in the query.
 // Returns a *NotSingularError when more than one Friendship ID is found.
 // Returns a *NotFoundError when no entities are found.
-func (fq *FriendshipQuery) OnlyID(ctx context.Context) (id int, err error) {
-	var ids []int
+func (fq *FriendshipQuery) OnlyID(ctx context.Context) (id string, err error) {
+	var ids []string
 	if ids, err = fq.Limit(2).IDs(setContextOp(ctx, fq.ctx, "OnlyID")); err != nil {
 		return
 	}
@@ -197,7 +197,7 @@ func (fq *FriendshipQuery) OnlyID(ctx context.Context) (id int, err error) {
 }
 
 // OnlyIDX is like OnlyID, but panics if an error occurs.
-func (fq *FriendshipQuery) OnlyIDX(ctx context.Context) int {
+func (fq *FriendshipQuery) OnlyIDX(ctx context.Context) string {
 	id, err := fq.OnlyID(ctx)
 	if err != nil {
 		panic(err)
@@ -225,7 +225,7 @@ func (fq *FriendshipQuery) AllX(ctx context.Context) []*Friendship {
 }
 
 // IDs executes the query and returns a list of Friendship IDs.
-func (fq *FriendshipQuery) IDs(ctx context.Context) (ids []int, err error) {
+func (fq *FriendshipQuery) IDs(ctx context.Context) (ids []string, err error) {
 	if fq.ctx.Unique == nil && fq.path != nil {
 		fq.Unique(true)
 	}
@@ -237,7 +237,7 @@ func (fq *FriendshipQuery) IDs(ctx context.Context) (ids []int, err error) {
 }
 
 // IDsX is like IDs, but panics if an error occurs.
-func (fq *FriendshipQuery) IDsX(ctx context.Context) []int {
+func (fq *FriendshipQuery) IDsX(ctx context.Context) []string {
 	ids, err := fq.IDs(ctx)
 	if err != nil {
 		panic(err)
@@ -512,7 +512,7 @@ func (fq *FriendshipQuery) sqlCount(ctx context.Context) (int, error) {
 }
 
 func (fq *FriendshipQuery) querySpec() *sqlgraph.QuerySpec {
-	_spec := sqlgraph.NewQuerySpec(friendship.Table, friendship.Columns, sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewQuerySpec(friendship.Table, friendship.Columns, sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeString))
 	_spec.From = fq.sql
 	if unique := fq.ctx.Unique; unique != nil {
 		_spec.Unique = *unique

--- a/_examples/basic/ent/friendship_update.go
+++ b/_examples/basic/ent/friendship_update.go
@@ -125,7 +125,7 @@ func (fu *FriendshipUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	if err := fu.check(); err != nil {
 		return n, err
 	}
-	_spec := sqlgraph.NewUpdateSpec(friendship.Table, friendship.Columns, sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewUpdateSpec(friendship.Table, friendship.Columns, sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeString))
 	if ps := fu.mutation.predicates; len(ps) > 0 {
 		_spec.Predicate = func(selector *sql.Selector) {
 			for i := range ps {
@@ -322,7 +322,7 @@ func (fuo *FriendshipUpdateOne) sqlSave(ctx context.Context) (_node *Friendship,
 	if err := fuo.check(); err != nil {
 		return _node, err
 	}
-	_spec := sqlgraph.NewUpdateSpec(friendship.Table, friendship.Columns, sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeInt))
+	_spec := sqlgraph.NewUpdateSpec(friendship.Table, friendship.Columns, sqlgraph.NewFieldSpec(friendship.FieldID, field.TypeString))
 	id, ok := fuo.mutation.ID()
 	if !ok {
 		return nil, &ValidationError{Name: "id", err: errors.New(`ent: missing "Friendship.id" for update`)}

--- a/_examples/basic/ent/friendshiphistory.go
+++ b/_examples/basic/ent/friendshiphistory.go
@@ -21,10 +21,10 @@ type FriendshipHistory struct {
 	ID int `json:"id,omitempty"`
 	// HistoryTime holds the value of the "history_time" field.
 	HistoryTime time.Time `json:"history_time,omitempty"`
-	// Ref holds the value of the "ref" field.
-	Ref int `json:"ref,omitempty"`
 	// Operation holds the value of the "operation" field.
 	Operation enthistory.OpType `json:"operation,omitempty"`
+	// Ref holds the value of the "ref" field.
+	Ref string `json:"ref,omitempty"`
 	// UpdatedBy holds the value of the "updated_by" field.
 	UpdatedBy *int `json:"updated_by,omitempty"`
 	// CreatedAt holds the value of the "created_at" field.
@@ -43,9 +43,9 @@ func (*FriendshipHistory) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case friendshiphistory.FieldID, friendshiphistory.FieldRef, friendshiphistory.FieldUpdatedBy, friendshiphistory.FieldCharacterID, friendshiphistory.FieldFriendID:
+		case friendshiphistory.FieldID, friendshiphistory.FieldUpdatedBy, friendshiphistory.FieldCharacterID, friendshiphistory.FieldFriendID:
 			values[i] = new(sql.NullInt64)
-		case friendshiphistory.FieldOperation:
+		case friendshiphistory.FieldOperation, friendshiphistory.FieldRef:
 			values[i] = new(sql.NullString)
 		case friendshiphistory.FieldHistoryTime, friendshiphistory.FieldCreatedAt, friendshiphistory.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -76,17 +76,17 @@ func (fh *FriendshipHistory) assignValues(columns []string, values []any) error 
 			} else if value.Valid {
 				fh.HistoryTime = value.Time
 			}
-		case friendshiphistory.FieldRef:
-			if value, ok := values[i].(*sql.NullInt64); !ok {
-				return fmt.Errorf("unexpected type %T for field ref", values[i])
-			} else if value.Valid {
-				fh.Ref = int(value.Int64)
-			}
 		case friendshiphistory.FieldOperation:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field operation", values[i])
 			} else if value.Valid {
 				fh.Operation = enthistory.OpType(value.String)
+			}
+		case friendshiphistory.FieldRef:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field ref", values[i])
+			} else if value.Valid {
+				fh.Ref = value.String
 			}
 		case friendshiphistory.FieldUpdatedBy:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -158,11 +158,11 @@ func (fh *FriendshipHistory) String() string {
 	builder.WriteString("history_time=")
 	builder.WriteString(fh.HistoryTime.Format(time.ANSIC))
 	builder.WriteString(", ")
-	builder.WriteString("ref=")
-	builder.WriteString(fmt.Sprintf("%v", fh.Ref))
-	builder.WriteString(", ")
 	builder.WriteString("operation=")
 	builder.WriteString(fmt.Sprintf("%v", fh.Operation))
+	builder.WriteString(", ")
+	builder.WriteString("ref=")
+	builder.WriteString(fh.Ref)
 	builder.WriteString(", ")
 	if v := fh.UpdatedBy; v != nil {
 		builder.WriteString("updated_by=")

--- a/_examples/basic/ent/friendshiphistory/friendshiphistory.go
+++ b/_examples/basic/ent/friendshiphistory/friendshiphistory.go
@@ -18,10 +18,10 @@ const (
 	FieldID = "id"
 	// FieldHistoryTime holds the string denoting the history_time field in the database.
 	FieldHistoryTime = "history_time"
-	// FieldRef holds the string denoting the ref field in the database.
-	FieldRef = "ref"
 	// FieldOperation holds the string denoting the operation field in the database.
 	FieldOperation = "operation"
+	// FieldRef holds the string denoting the ref field in the database.
+	FieldRef = "ref"
 	// FieldUpdatedBy holds the string denoting the updated_by field in the database.
 	FieldUpdatedBy = "updated_by"
 	// FieldCreatedAt holds the string denoting the created_at field in the database.
@@ -40,8 +40,8 @@ const (
 var Columns = []string{
 	FieldID,
 	FieldHistoryTime,
-	FieldRef,
 	FieldOperation,
+	FieldRef,
 	FieldUpdatedBy,
 	FieldCreatedAt,
 	FieldUpdatedAt,
@@ -91,14 +91,14 @@ func ByHistoryTime(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldHistoryTime, opts...).ToFunc()
 }
 
-// ByRef orders the results by the ref field.
-func ByRef(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldRef, opts...).ToFunc()
-}
-
 // ByOperation orders the results by the operation field.
 func ByOperation(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOperation, opts...).ToFunc()
+}
+
+// ByRef orders the results by the ref field.
+func ByRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRef, opts...).ToFunc()
 }
 
 // ByUpdatedBy orders the results by the updated_by field.

--- a/_examples/basic/ent/friendshiphistory/where.go
+++ b/_examples/basic/ent/friendshiphistory/where.go
@@ -62,7 +62,7 @@ func HistoryTime(v time.Time) predicate.FriendshipHistory {
 }
 
 // Ref applies equality check predicate on the "ref" field. It's identical to RefEQ.
-func Ref(v int) predicate.FriendshipHistory {
+func Ref(v string) predicate.FriendshipHistory {
 	return predicate.FriendshipHistory(sql.FieldEQ(FieldRef, v))
 }
 
@@ -131,56 +131,6 @@ func HistoryTimeLTE(v time.Time) predicate.FriendshipHistory {
 	return predicate.FriendshipHistory(sql.FieldLTE(FieldHistoryTime, v))
 }
 
-// RefEQ applies the EQ predicate on the "ref" field.
-func RefEQ(v int) predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldEQ(FieldRef, v))
-}
-
-// RefNEQ applies the NEQ predicate on the "ref" field.
-func RefNEQ(v int) predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldNEQ(FieldRef, v))
-}
-
-// RefIn applies the In predicate on the "ref" field.
-func RefIn(vs ...int) predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldIn(FieldRef, vs...))
-}
-
-// RefNotIn applies the NotIn predicate on the "ref" field.
-func RefNotIn(vs ...int) predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldNotIn(FieldRef, vs...))
-}
-
-// RefGT applies the GT predicate on the "ref" field.
-func RefGT(v int) predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldGT(FieldRef, v))
-}
-
-// RefGTE applies the GTE predicate on the "ref" field.
-func RefGTE(v int) predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldGTE(FieldRef, v))
-}
-
-// RefLT applies the LT predicate on the "ref" field.
-func RefLT(v int) predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldLT(FieldRef, v))
-}
-
-// RefLTE applies the LTE predicate on the "ref" field.
-func RefLTE(v int) predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldLTE(FieldRef, v))
-}
-
-// RefIsNil applies the IsNil predicate on the "ref" field.
-func RefIsNil() predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldIsNull(FieldRef))
-}
-
-// RefNotNil applies the NotNil predicate on the "ref" field.
-func RefNotNil() predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldNotNull(FieldRef))
-}
-
 // OperationEQ applies the EQ predicate on the "operation" field.
 func OperationEQ(v enthistory.OpType) predicate.FriendshipHistory {
 	return predicate.FriendshipHistory(sql.FieldEQ(FieldOperation, v))
@@ -199,6 +149,81 @@ func OperationIn(vs ...enthistory.OpType) predicate.FriendshipHistory {
 // OperationNotIn applies the NotIn predicate on the "operation" field.
 func OperationNotIn(vs ...enthistory.OpType) predicate.FriendshipHistory {
 	return predicate.FriendshipHistory(sql.FieldNotIn(FieldOperation, vs...))
+}
+
+// RefEQ applies the EQ predicate on the "ref" field.
+func RefEQ(v string) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldEQ(FieldRef, v))
+}
+
+// RefNEQ applies the NEQ predicate on the "ref" field.
+func RefNEQ(v string) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldNEQ(FieldRef, v))
+}
+
+// RefIn applies the In predicate on the "ref" field.
+func RefIn(vs ...string) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldIn(FieldRef, vs...))
+}
+
+// RefNotIn applies the NotIn predicate on the "ref" field.
+func RefNotIn(vs ...string) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldNotIn(FieldRef, vs...))
+}
+
+// RefGT applies the GT predicate on the "ref" field.
+func RefGT(v string) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldGT(FieldRef, v))
+}
+
+// RefGTE applies the GTE predicate on the "ref" field.
+func RefGTE(v string) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldGTE(FieldRef, v))
+}
+
+// RefLT applies the LT predicate on the "ref" field.
+func RefLT(v string) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldLT(FieldRef, v))
+}
+
+// RefLTE applies the LTE predicate on the "ref" field.
+func RefLTE(v string) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldLTE(FieldRef, v))
+}
+
+// RefContains applies the Contains predicate on the "ref" field.
+func RefContains(v string) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldContains(FieldRef, v))
+}
+
+// RefHasPrefix applies the HasPrefix predicate on the "ref" field.
+func RefHasPrefix(v string) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldHasPrefix(FieldRef, v))
+}
+
+// RefHasSuffix applies the HasSuffix predicate on the "ref" field.
+func RefHasSuffix(v string) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldHasSuffix(FieldRef, v))
+}
+
+// RefIsNil applies the IsNil predicate on the "ref" field.
+func RefIsNil() predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldIsNull(FieldRef))
+}
+
+// RefNotNil applies the NotNil predicate on the "ref" field.
+func RefNotNil() predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldNotNull(FieldRef))
+}
+
+// RefEqualFold applies the EqualFold predicate on the "ref" field.
+func RefEqualFold(v string) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldEqualFold(FieldRef, v))
+}
+
+// RefContainsFold applies the ContainsFold predicate on the "ref" field.
+func RefContainsFold(v string) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldContainsFold(FieldRef, v))
 }
 
 // UpdatedByEQ applies the EQ predicate on the "updated_by" field.

--- a/_examples/basic/ent/friendshiphistory_create.go
+++ b/_examples/basic/ent/friendshiphistory_create.go
@@ -36,23 +36,23 @@ func (fhc *FriendshipHistoryCreate) SetNillableHistoryTime(t *time.Time) *Friend
 	return fhc
 }
 
+// SetOperation sets the "operation" field.
+func (fhc *FriendshipHistoryCreate) SetOperation(et enthistory.OpType) *FriendshipHistoryCreate {
+	fhc.mutation.SetOperation(et)
+	return fhc
+}
+
 // SetRef sets the "ref" field.
-func (fhc *FriendshipHistoryCreate) SetRef(i int) *FriendshipHistoryCreate {
-	fhc.mutation.SetRef(i)
+func (fhc *FriendshipHistoryCreate) SetRef(s string) *FriendshipHistoryCreate {
+	fhc.mutation.SetRef(s)
 	return fhc
 }
 
 // SetNillableRef sets the "ref" field if the given value is not nil.
-func (fhc *FriendshipHistoryCreate) SetNillableRef(i *int) *FriendshipHistoryCreate {
-	if i != nil {
-		fhc.SetRef(*i)
+func (fhc *FriendshipHistoryCreate) SetNillableRef(s *string) *FriendshipHistoryCreate {
+	if s != nil {
+		fhc.SetRef(*s)
 	}
-	return fhc
-}
-
-// SetOperation sets the "operation" field.
-func (fhc *FriendshipHistoryCreate) SetOperation(et enthistory.OpType) *FriendshipHistoryCreate {
-	fhc.mutation.SetOperation(et)
 	return fhc
 }
 
@@ -214,13 +214,13 @@ func (fhc *FriendshipHistoryCreate) createSpec() (*FriendshipHistory, *sqlgraph.
 		_spec.SetField(friendshiphistory.FieldHistoryTime, field.TypeTime, value)
 		_node.HistoryTime = value
 	}
-	if value, ok := fhc.mutation.Ref(); ok {
-		_spec.SetField(friendshiphistory.FieldRef, field.TypeInt, value)
-		_node.Ref = value
-	}
 	if value, ok := fhc.mutation.Operation(); ok {
 		_spec.SetField(friendshiphistory.FieldOperation, field.TypeEnum, value)
 		_node.Operation = value
+	}
+	if value, ok := fhc.mutation.Ref(); ok {
+		_spec.SetField(friendshiphistory.FieldRef, field.TypeString, value)
+		_node.Ref = value
 	}
 	if value, ok := fhc.mutation.UpdatedBy(); ok {
 		_spec.SetField(friendshiphistory.FieldUpdatedBy, field.TypeInt, value)

--- a/_examples/basic/ent/friendshiphistory_update.go
+++ b/_examples/basic/ent/friendshiphistory_update.go
@@ -111,7 +111,7 @@ func (fhu *FriendshipHistoryUpdate) sqlSave(ctx context.Context) (n int, err err
 		}
 	}
 	if fhu.mutation.RefCleared() {
-		_spec.ClearField(friendshiphistory.FieldRef, field.TypeInt)
+		_spec.ClearField(friendshiphistory.FieldRef, field.TypeString)
 	}
 	if fhu.mutation.UpdatedByCleared() {
 		_spec.ClearField(friendshiphistory.FieldUpdatedBy, field.TypeInt)
@@ -263,7 +263,7 @@ func (fhuo *FriendshipHistoryUpdateOne) sqlSave(ctx context.Context) (_node *Fri
 		}
 	}
 	if fhuo.mutation.RefCleared() {
-		_spec.ClearField(friendshiphistory.FieldRef, field.TypeInt)
+		_spec.ClearField(friendshiphistory.FieldRef, field.TypeString)
 	}
 	if fhuo.mutation.UpdatedByCleared() {
 		_spec.ClearField(friendshiphistory.FieldUpdatedBy, field.TypeInt)

--- a/_examples/basic/ent/migrate/schema.go
+++ b/_examples/basic/ent/migrate/schema.go
@@ -27,8 +27,8 @@ var (
 	CharacterHistoryColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "history_time", Type: field.TypeTime},
-		{Name: "ref", Type: field.TypeInt, Nullable: true},
 		{Name: "operation", Type: field.TypeEnum, Enums: []string{"INSERT", "UPDATE", "DELETE"}},
+		{Name: "ref", Type: field.TypeInt, Nullable: true},
 		{Name: "updated_by", Type: field.TypeInt, Nullable: true},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
@@ -50,7 +50,7 @@ var (
 	}
 	// FriendshipColumns holds the columns for the "friendship" table.
 	FriendshipColumns = []*schema.Column{
-		{Name: "id", Type: field.TypeInt, Increment: true},
+		{Name: "id", Type: field.TypeString},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "character_id", Type: field.TypeInt},
@@ -87,8 +87,8 @@ var (
 	FriendshipHistoryColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "history_time", Type: field.TypeTime},
-		{Name: "ref", Type: field.TypeInt, Nullable: true},
 		{Name: "operation", Type: field.TypeEnum, Enums: []string{"INSERT", "UPDATE", "DELETE"}},
+		{Name: "ref", Type: field.TypeString, Nullable: true},
 		{Name: "updated_by", Type: field.TypeInt, Nullable: true},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},

--- a/_examples/basic/ent/schema/character_history.go
+++ b/_examples/basic/ent/schema/character_history.go
@@ -49,7 +49,14 @@ func (CharacterHistory) Fields() []ent.Field {
 			Nillable(),
 	}
 
-	return append(historyFields, Character{}.Fields()...)
+	original := Character{}
+	for _, field := range original.Fields() {
+		if field.Descriptor().Name != "id" {
+			historyFields = append(historyFields, field)
+		}
+	}
+
+	return historyFields
 }
 
 // Mixin of the CharacterHistory.

--- a/_examples/basic/ent/schema/friendship.go
+++ b/_examples/basic/ent/schema/friendship.go
@@ -27,6 +27,7 @@ func (Friendship) Annotations() []schema.Annotation {
 // Fields of the Friendship.
 func (Friendship) Fields() []ent.Field {
 	return []ent.Field{
+		field.String("id"),
 		field.Int("character_id"),
 		field.Int("friend_id"),
 	}

--- a/_examples/basic/ent/schema/friendship_history.go
+++ b/_examples/basic/ent/schema/friendship_history.go
@@ -37,7 +37,7 @@ func (FriendshipHistory) Fields() []ent.Field {
 		field.Time("history_time").
 			Default(time.Now).
 			Immutable(),
-		field.Int("ref").
+		field.String("ref").
 			Immutable().
 			Optional(),
 		field.Enum("operation").
@@ -49,7 +49,14 @@ func (FriendshipHistory) Fields() []ent.Field {
 			Nillable(),
 	}
 
-	return append(historyFields, Friendship{}.Fields()...)
+	original := Friendship{}
+	for _, field := range original.Fields() {
+		if field.Descriptor().Name != "id" {
+			historyFields = append(historyFields, field)
+		}
+	}
+
+	return historyFields
 }
 
 // Mixin of the FriendshipHistory.

--- a/_examples/custompaths/ent/some/otherschema/character_history.go
+++ b/_examples/custompaths/ent/some/otherschema/character_history.go
@@ -44,7 +44,14 @@ func (CharacterHistory) Fields() []ent.Field {
 			Immutable(),
 	}
 
-	return append(historyFields, Character{}.Fields()...)
+	original := Character{}
+	for _, field := range original.Fields() {
+		if field.Descriptor().Name != "id" {
+			historyFields = append(historyFields, field)
+		}
+	}
+
+	return historyFields
 }
 
 // Mixin of the CharacterHistory.

--- a/_examples/custompaths/ent/some/otherschema/friendship_history.go
+++ b/_examples/custompaths/ent/some/otherschema/friendship_history.go
@@ -44,7 +44,14 @@ func (FriendshipHistory) Fields() []ent.Field {
 			Immutable(),
 	}
 
-	return append(historyFields, Friendship{}.Fields()...)
+	original := Friendship{}
+	for _, field := range original.Fields() {
+		if field.Descriptor().Name != "id" {
+			historyFields = append(historyFields, field)
+		}
+	}
+
+	return historyFields
 }
 
 // Mixin of the FriendshipHistory.

--- a/_examples/custompaths/internal/ent/characterhistory.go
+++ b/_examples/custompaths/internal/ent/characterhistory.go
@@ -21,10 +21,10 @@ type CharacterHistory struct {
 	ID int `json:"id,omitempty"`
 	// HistoryTime holds the value of the "history_time" field.
 	HistoryTime time.Time `json:"history_time,omitempty"`
-	// Ref holds the value of the "ref" field.
-	Ref int `json:"ref,omitempty"`
 	// Operation holds the value of the "operation" field.
 	Operation enthistory.OpType `json:"operation,omitempty"`
+	// Ref holds the value of the "ref" field.
+	Ref int `json:"ref,omitempty"`
 	// Age holds the value of the "age" field.
 	Age int `json:"age,omitempty"`
 	// Name holds the value of the "name" field.
@@ -70,17 +70,17 @@ func (ch *CharacterHistory) assignValues(columns []string, values []any) error {
 			} else if value.Valid {
 				ch.HistoryTime = value.Time
 			}
-		case characterhistory.FieldRef:
-			if value, ok := values[i].(*sql.NullInt64); !ok {
-				return fmt.Errorf("unexpected type %T for field ref", values[i])
-			} else if value.Valid {
-				ch.Ref = int(value.Int64)
-			}
 		case characterhistory.FieldOperation:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field operation", values[i])
 			} else if value.Valid {
 				ch.Operation = enthistory.OpType(value.String)
+			}
+		case characterhistory.FieldRef:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field ref", values[i])
+			} else if value.Valid {
+				ch.Ref = int(value.Int64)
 			}
 		case characterhistory.FieldAge:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -133,11 +133,11 @@ func (ch *CharacterHistory) String() string {
 	builder.WriteString("history_time=")
 	builder.WriteString(ch.HistoryTime.Format(time.ANSIC))
 	builder.WriteString(", ")
-	builder.WriteString("ref=")
-	builder.WriteString(fmt.Sprintf("%v", ch.Ref))
-	builder.WriteString(", ")
 	builder.WriteString("operation=")
 	builder.WriteString(fmt.Sprintf("%v", ch.Operation))
+	builder.WriteString(", ")
+	builder.WriteString("ref=")
+	builder.WriteString(fmt.Sprintf("%v", ch.Ref))
 	builder.WriteString(", ")
 	builder.WriteString("age=")
 	builder.WriteString(fmt.Sprintf("%v", ch.Age))

--- a/_examples/custompaths/internal/ent/characterhistory/characterhistory.go
+++ b/_examples/custompaths/internal/ent/characterhistory/characterhistory.go
@@ -18,10 +18,10 @@ const (
 	FieldID = "id"
 	// FieldHistoryTime holds the string denoting the history_time field in the database.
 	FieldHistoryTime = "history_time"
-	// FieldRef holds the string denoting the ref field in the database.
-	FieldRef = "ref"
 	// FieldOperation holds the string denoting the operation field in the database.
 	FieldOperation = "operation"
+	// FieldRef holds the string denoting the ref field in the database.
+	FieldRef = "ref"
 	// FieldAge holds the string denoting the age field in the database.
 	FieldAge = "age"
 	// FieldName holds the string denoting the name field in the database.
@@ -34,8 +34,8 @@ const (
 var Columns = []string{
 	FieldID,
 	FieldHistoryTime,
-	FieldRef,
 	FieldOperation,
+	FieldRef,
 	FieldAge,
 	FieldName,
 }
@@ -80,14 +80,14 @@ func ByHistoryTime(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldHistoryTime, opts...).ToFunc()
 }
 
-// ByRef orders the results by the ref field.
-func ByRef(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldRef, opts...).ToFunc()
-}
-
 // ByOperation orders the results by the operation field.
 func ByOperation(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOperation, opts...).ToFunc()
+}
+
+// ByRef orders the results by the ref field.
+func ByRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRef, opts...).ToFunc()
 }
 
 // ByAge orders the results by the age field.

--- a/_examples/custompaths/internal/ent/characterhistory/where.go
+++ b/_examples/custompaths/internal/ent/characterhistory/where.go
@@ -116,6 +116,26 @@ func HistoryTimeLTE(v time.Time) predicate.CharacterHistory {
 	return predicate.CharacterHistory(sql.FieldLTE(FieldHistoryTime, v))
 }
 
+// OperationEQ applies the EQ predicate on the "operation" field.
+func OperationEQ(v enthistory.OpType) predicate.CharacterHistory {
+	return predicate.CharacterHistory(sql.FieldEQ(FieldOperation, v))
+}
+
+// OperationNEQ applies the NEQ predicate on the "operation" field.
+func OperationNEQ(v enthistory.OpType) predicate.CharacterHistory {
+	return predicate.CharacterHistory(sql.FieldNEQ(FieldOperation, v))
+}
+
+// OperationIn applies the In predicate on the "operation" field.
+func OperationIn(vs ...enthistory.OpType) predicate.CharacterHistory {
+	return predicate.CharacterHistory(sql.FieldIn(FieldOperation, vs...))
+}
+
+// OperationNotIn applies the NotIn predicate on the "operation" field.
+func OperationNotIn(vs ...enthistory.OpType) predicate.CharacterHistory {
+	return predicate.CharacterHistory(sql.FieldNotIn(FieldOperation, vs...))
+}
+
 // RefEQ applies the EQ predicate on the "ref" field.
 func RefEQ(v int) predicate.CharacterHistory {
 	return predicate.CharacterHistory(sql.FieldEQ(FieldRef, v))
@@ -164,26 +184,6 @@ func RefIsNil() predicate.CharacterHistory {
 // RefNotNil applies the NotNil predicate on the "ref" field.
 func RefNotNil() predicate.CharacterHistory {
 	return predicate.CharacterHistory(sql.FieldNotNull(FieldRef))
-}
-
-// OperationEQ applies the EQ predicate on the "operation" field.
-func OperationEQ(v enthistory.OpType) predicate.CharacterHistory {
-	return predicate.CharacterHistory(sql.FieldEQ(FieldOperation, v))
-}
-
-// OperationNEQ applies the NEQ predicate on the "operation" field.
-func OperationNEQ(v enthistory.OpType) predicate.CharacterHistory {
-	return predicate.CharacterHistory(sql.FieldNEQ(FieldOperation, v))
-}
-
-// OperationIn applies the In predicate on the "operation" field.
-func OperationIn(vs ...enthistory.OpType) predicate.CharacterHistory {
-	return predicate.CharacterHistory(sql.FieldIn(FieldOperation, vs...))
-}
-
-// OperationNotIn applies the NotIn predicate on the "operation" field.
-func OperationNotIn(vs ...enthistory.OpType) predicate.CharacterHistory {
-	return predicate.CharacterHistory(sql.FieldNotIn(FieldOperation, vs...))
 }
 
 // AgeEQ applies the EQ predicate on the "age" field.

--- a/_examples/custompaths/internal/ent/characterhistory_create.go
+++ b/_examples/custompaths/internal/ent/characterhistory_create.go
@@ -36,6 +36,12 @@ func (chc *CharacterHistoryCreate) SetNillableHistoryTime(t *time.Time) *Charact
 	return chc
 }
 
+// SetOperation sets the "operation" field.
+func (chc *CharacterHistoryCreate) SetOperation(et enthistory.OpType) *CharacterHistoryCreate {
+	chc.mutation.SetOperation(et)
+	return chc
+}
+
 // SetRef sets the "ref" field.
 func (chc *CharacterHistoryCreate) SetRef(i int) *CharacterHistoryCreate {
 	chc.mutation.SetRef(i)
@@ -47,12 +53,6 @@ func (chc *CharacterHistoryCreate) SetNillableRef(i *int) *CharacterHistoryCreat
 	if i != nil {
 		chc.SetRef(*i)
 	}
-	return chc
-}
-
-// SetOperation sets the "operation" field.
-func (chc *CharacterHistoryCreate) SetOperation(et enthistory.OpType) *CharacterHistoryCreate {
-	chc.mutation.SetOperation(et)
 	return chc
 }
 
@@ -163,13 +163,13 @@ func (chc *CharacterHistoryCreate) createSpec() (*CharacterHistory, *sqlgraph.Cr
 		_spec.SetField(characterhistory.FieldHistoryTime, field.TypeTime, value)
 		_node.HistoryTime = value
 	}
-	if value, ok := chc.mutation.Ref(); ok {
-		_spec.SetField(characterhistory.FieldRef, field.TypeInt, value)
-		_node.Ref = value
-	}
 	if value, ok := chc.mutation.Operation(); ok {
 		_spec.SetField(characterhistory.FieldOperation, field.TypeEnum, value)
 		_node.Operation = value
+	}
+	if value, ok := chc.mutation.Ref(); ok {
+		_spec.SetField(characterhistory.FieldRef, field.TypeInt, value)
+		_node.Ref = value
 	}
 	if value, ok := chc.mutation.Age(); ok {
 		_spec.SetField(characterhistory.FieldAge, field.TypeInt, value)

--- a/_examples/custompaths/internal/ent/friendshiphistory.go
+++ b/_examples/custompaths/internal/ent/friendshiphistory.go
@@ -21,10 +21,10 @@ type FriendshipHistory struct {
 	ID int `json:"id,omitempty"`
 	// HistoryTime holds the value of the "history_time" field.
 	HistoryTime time.Time `json:"history_time,omitempty"`
-	// Ref holds the value of the "ref" field.
-	Ref int `json:"ref,omitempty"`
 	// Operation holds the value of the "operation" field.
 	Operation enthistory.OpType `json:"operation,omitempty"`
+	// Ref holds the value of the "ref" field.
+	Ref int `json:"ref,omitempty"`
 	// CharacterID holds the value of the "character_id" field.
 	CharacterID int `json:"character_id,omitempty"`
 	// FriendID holds the value of the "friend_id" field.
@@ -70,17 +70,17 @@ func (fh *FriendshipHistory) assignValues(columns []string, values []any) error 
 			} else if value.Valid {
 				fh.HistoryTime = value.Time
 			}
-		case friendshiphistory.FieldRef:
-			if value, ok := values[i].(*sql.NullInt64); !ok {
-				return fmt.Errorf("unexpected type %T for field ref", values[i])
-			} else if value.Valid {
-				fh.Ref = int(value.Int64)
-			}
 		case friendshiphistory.FieldOperation:
 			if value, ok := values[i].(*sql.NullString); !ok {
 				return fmt.Errorf("unexpected type %T for field operation", values[i])
 			} else if value.Valid {
 				fh.Operation = enthistory.OpType(value.String)
+			}
+		case friendshiphistory.FieldRef:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field ref", values[i])
+			} else if value.Valid {
+				fh.Ref = int(value.Int64)
 			}
 		case friendshiphistory.FieldCharacterID:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -133,11 +133,11 @@ func (fh *FriendshipHistory) String() string {
 	builder.WriteString("history_time=")
 	builder.WriteString(fh.HistoryTime.Format(time.ANSIC))
 	builder.WriteString(", ")
-	builder.WriteString("ref=")
-	builder.WriteString(fmt.Sprintf("%v", fh.Ref))
-	builder.WriteString(", ")
 	builder.WriteString("operation=")
 	builder.WriteString(fmt.Sprintf("%v", fh.Operation))
+	builder.WriteString(", ")
+	builder.WriteString("ref=")
+	builder.WriteString(fmt.Sprintf("%v", fh.Ref))
 	builder.WriteString(", ")
 	builder.WriteString("character_id=")
 	builder.WriteString(fmt.Sprintf("%v", fh.CharacterID))

--- a/_examples/custompaths/internal/ent/friendshiphistory/friendshiphistory.go
+++ b/_examples/custompaths/internal/ent/friendshiphistory/friendshiphistory.go
@@ -18,10 +18,10 @@ const (
 	FieldID = "id"
 	// FieldHistoryTime holds the string denoting the history_time field in the database.
 	FieldHistoryTime = "history_time"
-	// FieldRef holds the string denoting the ref field in the database.
-	FieldRef = "ref"
 	// FieldOperation holds the string denoting the operation field in the database.
 	FieldOperation = "operation"
+	// FieldRef holds the string denoting the ref field in the database.
+	FieldRef = "ref"
 	// FieldCharacterID holds the string denoting the character_id field in the database.
 	FieldCharacterID = "character_id"
 	// FieldFriendID holds the string denoting the friend_id field in the database.
@@ -34,8 +34,8 @@ const (
 var Columns = []string{
 	FieldID,
 	FieldHistoryTime,
-	FieldRef,
 	FieldOperation,
+	FieldRef,
 	FieldCharacterID,
 	FieldFriendID,
 }
@@ -78,14 +78,14 @@ func ByHistoryTime(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldHistoryTime, opts...).ToFunc()
 }
 
-// ByRef orders the results by the ref field.
-func ByRef(opts ...sql.OrderTermOption) OrderOption {
-	return sql.OrderByField(FieldRef, opts...).ToFunc()
-}
-
 // ByOperation orders the results by the operation field.
 func ByOperation(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldOperation, opts...).ToFunc()
+}
+
+// ByRef orders the results by the ref field.
+func ByRef(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldRef, opts...).ToFunc()
 }
 
 // ByCharacterID orders the results by the character_id field.

--- a/_examples/custompaths/internal/ent/friendshiphistory/where.go
+++ b/_examples/custompaths/internal/ent/friendshiphistory/where.go
@@ -116,6 +116,26 @@ func HistoryTimeLTE(v time.Time) predicate.FriendshipHistory {
 	return predicate.FriendshipHistory(sql.FieldLTE(FieldHistoryTime, v))
 }
 
+// OperationEQ applies the EQ predicate on the "operation" field.
+func OperationEQ(v enthistory.OpType) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldEQ(FieldOperation, v))
+}
+
+// OperationNEQ applies the NEQ predicate on the "operation" field.
+func OperationNEQ(v enthistory.OpType) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldNEQ(FieldOperation, v))
+}
+
+// OperationIn applies the In predicate on the "operation" field.
+func OperationIn(vs ...enthistory.OpType) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldIn(FieldOperation, vs...))
+}
+
+// OperationNotIn applies the NotIn predicate on the "operation" field.
+func OperationNotIn(vs ...enthistory.OpType) predicate.FriendshipHistory {
+	return predicate.FriendshipHistory(sql.FieldNotIn(FieldOperation, vs...))
+}
+
 // RefEQ applies the EQ predicate on the "ref" field.
 func RefEQ(v int) predicate.FriendshipHistory {
 	return predicate.FriendshipHistory(sql.FieldEQ(FieldRef, v))
@@ -164,26 +184,6 @@ func RefIsNil() predicate.FriendshipHistory {
 // RefNotNil applies the NotNil predicate on the "ref" field.
 func RefNotNil() predicate.FriendshipHistory {
 	return predicate.FriendshipHistory(sql.FieldNotNull(FieldRef))
-}
-
-// OperationEQ applies the EQ predicate on the "operation" field.
-func OperationEQ(v enthistory.OpType) predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldEQ(FieldOperation, v))
-}
-
-// OperationNEQ applies the NEQ predicate on the "operation" field.
-func OperationNEQ(v enthistory.OpType) predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldNEQ(FieldOperation, v))
-}
-
-// OperationIn applies the In predicate on the "operation" field.
-func OperationIn(vs ...enthistory.OpType) predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldIn(FieldOperation, vs...))
-}
-
-// OperationNotIn applies the NotIn predicate on the "operation" field.
-func OperationNotIn(vs ...enthistory.OpType) predicate.FriendshipHistory {
-	return predicate.FriendshipHistory(sql.FieldNotIn(FieldOperation, vs...))
 }
 
 // CharacterIDEQ applies the EQ predicate on the "character_id" field.

--- a/_examples/custompaths/internal/ent/friendshiphistory_create.go
+++ b/_examples/custompaths/internal/ent/friendshiphistory_create.go
@@ -36,6 +36,12 @@ func (fhc *FriendshipHistoryCreate) SetNillableHistoryTime(t *time.Time) *Friend
 	return fhc
 }
 
+// SetOperation sets the "operation" field.
+func (fhc *FriendshipHistoryCreate) SetOperation(et enthistory.OpType) *FriendshipHistoryCreate {
+	fhc.mutation.SetOperation(et)
+	return fhc
+}
+
 // SetRef sets the "ref" field.
 func (fhc *FriendshipHistoryCreate) SetRef(i int) *FriendshipHistoryCreate {
 	fhc.mutation.SetRef(i)
@@ -47,12 +53,6 @@ func (fhc *FriendshipHistoryCreate) SetNillableRef(i *int) *FriendshipHistoryCre
 	if i != nil {
 		fhc.SetRef(*i)
 	}
-	return fhc
-}
-
-// SetOperation sets the "operation" field.
-func (fhc *FriendshipHistoryCreate) SetOperation(et enthistory.OpType) *FriendshipHistoryCreate {
-	fhc.mutation.SetOperation(et)
 	return fhc
 }
 
@@ -158,13 +158,13 @@ func (fhc *FriendshipHistoryCreate) createSpec() (*FriendshipHistory, *sqlgraph.
 		_spec.SetField(friendshiphistory.FieldHistoryTime, field.TypeTime, value)
 		_node.HistoryTime = value
 	}
-	if value, ok := fhc.mutation.Ref(); ok {
-		_spec.SetField(friendshiphistory.FieldRef, field.TypeInt, value)
-		_node.Ref = value
-	}
 	if value, ok := fhc.mutation.Operation(); ok {
 		_spec.SetField(friendshiphistory.FieldOperation, field.TypeEnum, value)
 		_node.Operation = value
+	}
+	if value, ok := fhc.mutation.Ref(); ok {
+		_spec.SetField(friendshiphistory.FieldRef, field.TypeInt, value)
+		_node.Ref = value
 	}
 	if value, ok := fhc.mutation.CharacterID(); ok {
 		_spec.SetField(friendshiphistory.FieldCharacterID, field.TypeInt, value)

--- a/_examples/custompaths/internal/ent/migrate/schema.go
+++ b/_examples/custompaths/internal/ent/migrate/schema.go
@@ -25,8 +25,8 @@ var (
 	CharacterHistoryColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "history_time", Type: field.TypeTime},
-		{Name: "ref", Type: field.TypeInt, Nullable: true},
 		{Name: "operation", Type: field.TypeEnum, Enums: []string{"INSERT", "UPDATE", "DELETE"}},
+		{Name: "ref", Type: field.TypeInt, Nullable: true},
 		{Name: "age", Type: field.TypeInt},
 		{Name: "name", Type: field.TypeString},
 	}
@@ -73,8 +73,8 @@ var (
 	FriendshipHistoryColumns = []*schema.Column{
 		{Name: "id", Type: field.TypeInt, Increment: true},
 		{Name: "history_time", Type: field.TypeTime},
-		{Name: "ref", Type: field.TypeInt, Nullable: true},
 		{Name: "operation", Type: field.TypeEnum, Enums: []string{"INSERT", "UPDATE", "DELETE"}},
+		{Name: "ref", Type: field.TypeInt, Nullable: true},
 		{Name: "character_id", Type: field.TypeInt},
 		{Name: "friend_id", Type: field.TypeInt},
 	}

--- a/_examples/custompaths/internal/ent/mutation.go
+++ b/_examples/custompaths/internal/ent/mutation.go
@@ -634,9 +634,9 @@ type CharacterHistoryMutation struct {
 	typ           string
 	id            *int
 	history_time  *time.Time
+	operation     *enthistory.OpType
 	ref           *int
 	addref        *int
-	operation     *enthistory.OpType
 	age           *int
 	addage        *int
 	name          *string
@@ -780,6 +780,42 @@ func (m *CharacterHistoryMutation) ResetHistoryTime() {
 	m.history_time = nil
 }
 
+// SetOperation sets the "operation" field.
+func (m *CharacterHistoryMutation) SetOperation(et enthistory.OpType) {
+	m.operation = &et
+}
+
+// Operation returns the value of the "operation" field in the mutation.
+func (m *CharacterHistoryMutation) Operation() (r enthistory.OpType, exists bool) {
+	v := m.operation
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldOperation returns the old "operation" field's value of the CharacterHistory entity.
+// If the CharacterHistory object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CharacterHistoryMutation) OldOperation(ctx context.Context) (v enthistory.OpType, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldOperation is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldOperation requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldOperation: %w", err)
+	}
+	return oldValue.Operation, nil
+}
+
+// ResetOperation resets all changes to the "operation" field.
+func (m *CharacterHistoryMutation) ResetOperation() {
+	m.operation = nil
+}
+
 // SetRef sets the "ref" field.
 func (m *CharacterHistoryMutation) SetRef(i int) {
 	m.ref = &i
@@ -848,42 +884,6 @@ func (m *CharacterHistoryMutation) ResetRef() {
 	m.ref = nil
 	m.addref = nil
 	delete(m.clearedFields, characterhistory.FieldRef)
-}
-
-// SetOperation sets the "operation" field.
-func (m *CharacterHistoryMutation) SetOperation(et enthistory.OpType) {
-	m.operation = &et
-}
-
-// Operation returns the value of the "operation" field in the mutation.
-func (m *CharacterHistoryMutation) Operation() (r enthistory.OpType, exists bool) {
-	v := m.operation
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldOperation returns the old "operation" field's value of the CharacterHistory entity.
-// If the CharacterHistory object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *CharacterHistoryMutation) OldOperation(ctx context.Context) (v enthistory.OpType, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldOperation is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldOperation requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldOperation: %w", err)
-	}
-	return oldValue.Operation, nil
-}
-
-// ResetOperation resets all changes to the "operation" field.
-func (m *CharacterHistoryMutation) ResetOperation() {
-	m.operation = nil
 }
 
 // SetAge sets the "age" field.
@@ -1016,11 +1016,11 @@ func (m *CharacterHistoryMutation) Fields() []string {
 	if m.history_time != nil {
 		fields = append(fields, characterhistory.FieldHistoryTime)
 	}
-	if m.ref != nil {
-		fields = append(fields, characterhistory.FieldRef)
-	}
 	if m.operation != nil {
 		fields = append(fields, characterhistory.FieldOperation)
+	}
+	if m.ref != nil {
+		fields = append(fields, characterhistory.FieldRef)
 	}
 	if m.age != nil {
 		fields = append(fields, characterhistory.FieldAge)
@@ -1038,10 +1038,10 @@ func (m *CharacterHistoryMutation) Field(name string) (ent.Value, bool) {
 	switch name {
 	case characterhistory.FieldHistoryTime:
 		return m.HistoryTime()
-	case characterhistory.FieldRef:
-		return m.Ref()
 	case characterhistory.FieldOperation:
 		return m.Operation()
+	case characterhistory.FieldRef:
+		return m.Ref()
 	case characterhistory.FieldAge:
 		return m.Age()
 	case characterhistory.FieldName:
@@ -1057,10 +1057,10 @@ func (m *CharacterHistoryMutation) OldField(ctx context.Context, name string) (e
 	switch name {
 	case characterhistory.FieldHistoryTime:
 		return m.OldHistoryTime(ctx)
-	case characterhistory.FieldRef:
-		return m.OldRef(ctx)
 	case characterhistory.FieldOperation:
 		return m.OldOperation(ctx)
+	case characterhistory.FieldRef:
+		return m.OldRef(ctx)
 	case characterhistory.FieldAge:
 		return m.OldAge(ctx)
 	case characterhistory.FieldName:
@@ -1081,19 +1081,19 @@ func (m *CharacterHistoryMutation) SetField(name string, value ent.Value) error 
 		}
 		m.SetHistoryTime(v)
 		return nil
-	case characterhistory.FieldRef:
-		v, ok := value.(int)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetRef(v)
-		return nil
 	case characterhistory.FieldOperation:
 		v, ok := value.(enthistory.OpType)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetOperation(v)
+		return nil
+	case characterhistory.FieldRef:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRef(v)
 		return nil
 	case characterhistory.FieldAge:
 		v, ok := value.(int)
@@ -1197,11 +1197,11 @@ func (m *CharacterHistoryMutation) ResetField(name string) error {
 	case characterhistory.FieldHistoryTime:
 		m.ResetHistoryTime()
 		return nil
-	case characterhistory.FieldRef:
-		m.ResetRef()
-		return nil
 	case characterhistory.FieldOperation:
 		m.ResetOperation()
+		return nil
+	case characterhistory.FieldRef:
+		m.ResetRef()
 		return nil
 	case characterhistory.FieldAge:
 		m.ResetAge()
@@ -1749,9 +1749,9 @@ type FriendshipHistoryMutation struct {
 	typ             string
 	id              *int
 	history_time    *time.Time
+	operation       *enthistory.OpType
 	ref             *int
 	addref          *int
-	operation       *enthistory.OpType
 	character_id    *int
 	addcharacter_id *int
 	friend_id       *int
@@ -1896,6 +1896,42 @@ func (m *FriendshipHistoryMutation) ResetHistoryTime() {
 	m.history_time = nil
 }
 
+// SetOperation sets the "operation" field.
+func (m *FriendshipHistoryMutation) SetOperation(et enthistory.OpType) {
+	m.operation = &et
+}
+
+// Operation returns the value of the "operation" field in the mutation.
+func (m *FriendshipHistoryMutation) Operation() (r enthistory.OpType, exists bool) {
+	v := m.operation
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldOperation returns the old "operation" field's value of the FriendshipHistory entity.
+// If the FriendshipHistory object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *FriendshipHistoryMutation) OldOperation(ctx context.Context) (v enthistory.OpType, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldOperation is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldOperation requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldOperation: %w", err)
+	}
+	return oldValue.Operation, nil
+}
+
+// ResetOperation resets all changes to the "operation" field.
+func (m *FriendshipHistoryMutation) ResetOperation() {
+	m.operation = nil
+}
+
 // SetRef sets the "ref" field.
 func (m *FriendshipHistoryMutation) SetRef(i int) {
 	m.ref = &i
@@ -1964,42 +2000,6 @@ func (m *FriendshipHistoryMutation) ResetRef() {
 	m.ref = nil
 	m.addref = nil
 	delete(m.clearedFields, friendshiphistory.FieldRef)
-}
-
-// SetOperation sets the "operation" field.
-func (m *FriendshipHistoryMutation) SetOperation(et enthistory.OpType) {
-	m.operation = &et
-}
-
-// Operation returns the value of the "operation" field in the mutation.
-func (m *FriendshipHistoryMutation) Operation() (r enthistory.OpType, exists bool) {
-	v := m.operation
-	if v == nil {
-		return
-	}
-	return *v, true
-}
-
-// OldOperation returns the old "operation" field's value of the FriendshipHistory entity.
-// If the FriendshipHistory object wasn't provided to the builder, the object is fetched from the database.
-// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *FriendshipHistoryMutation) OldOperation(ctx context.Context) (v enthistory.OpType, err error) {
-	if !m.op.Is(OpUpdateOne) {
-		return v, errors.New("OldOperation is only allowed on UpdateOne operations")
-	}
-	if m.id == nil || m.oldValue == nil {
-		return v, errors.New("OldOperation requires an ID field in the mutation")
-	}
-	oldValue, err := m.oldValue(ctx)
-	if err != nil {
-		return v, fmt.Errorf("querying old value for OldOperation: %w", err)
-	}
-	return oldValue.Operation, nil
-}
-
-// ResetOperation resets all changes to the "operation" field.
-func (m *FriendshipHistoryMutation) ResetOperation() {
-	m.operation = nil
 }
 
 // SetCharacterID sets the "character_id" field.
@@ -2152,11 +2152,11 @@ func (m *FriendshipHistoryMutation) Fields() []string {
 	if m.history_time != nil {
 		fields = append(fields, friendshiphistory.FieldHistoryTime)
 	}
-	if m.ref != nil {
-		fields = append(fields, friendshiphistory.FieldRef)
-	}
 	if m.operation != nil {
 		fields = append(fields, friendshiphistory.FieldOperation)
+	}
+	if m.ref != nil {
+		fields = append(fields, friendshiphistory.FieldRef)
 	}
 	if m.character_id != nil {
 		fields = append(fields, friendshiphistory.FieldCharacterID)
@@ -2174,10 +2174,10 @@ func (m *FriendshipHistoryMutation) Field(name string) (ent.Value, bool) {
 	switch name {
 	case friendshiphistory.FieldHistoryTime:
 		return m.HistoryTime()
-	case friendshiphistory.FieldRef:
-		return m.Ref()
 	case friendshiphistory.FieldOperation:
 		return m.Operation()
+	case friendshiphistory.FieldRef:
+		return m.Ref()
 	case friendshiphistory.FieldCharacterID:
 		return m.CharacterID()
 	case friendshiphistory.FieldFriendID:
@@ -2193,10 +2193,10 @@ func (m *FriendshipHistoryMutation) OldField(ctx context.Context, name string) (
 	switch name {
 	case friendshiphistory.FieldHistoryTime:
 		return m.OldHistoryTime(ctx)
-	case friendshiphistory.FieldRef:
-		return m.OldRef(ctx)
 	case friendshiphistory.FieldOperation:
 		return m.OldOperation(ctx)
+	case friendshiphistory.FieldRef:
+		return m.OldRef(ctx)
 	case friendshiphistory.FieldCharacterID:
 		return m.OldCharacterID(ctx)
 	case friendshiphistory.FieldFriendID:
@@ -2217,19 +2217,19 @@ func (m *FriendshipHistoryMutation) SetField(name string, value ent.Value) error
 		}
 		m.SetHistoryTime(v)
 		return nil
-	case friendshiphistory.FieldRef:
-		v, ok := value.(int)
-		if !ok {
-			return fmt.Errorf("unexpected type %T for field %s", value, name)
-		}
-		m.SetRef(v)
-		return nil
 	case friendshiphistory.FieldOperation:
 		v, ok := value.(enthistory.OpType)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetOperation(v)
+		return nil
+	case friendshiphistory.FieldRef:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetRef(v)
 		return nil
 	case friendshiphistory.FieldCharacterID:
 		v, ok := value.(int)
@@ -2345,11 +2345,11 @@ func (m *FriendshipHistoryMutation) ResetField(name string) error {
 	case friendshiphistory.FieldHistoryTime:
 		m.ResetHistoryTime()
 		return nil
-	case friendshiphistory.FieldRef:
-		m.ResetRef()
-		return nil
 	case friendshiphistory.FieldOperation:
 		m.ResetOperation()
+		return nil
+	case friendshiphistory.FieldRef:
+		m.ResetRef()
 		return nil
 	case friendshiphistory.FieldCharacterID:
 		m.ResetCharacterID()

--- a/_examples/enthistory_test.go
+++ b/_examples/enthistory_test.go
@@ -388,8 +388,7 @@ func TestEntHistory(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		err := os.Remove("entdb")
-		assert.NoError(t, err)
+		os.Remove("entdb")
 
 		opts := []enttest.Option{
 			enttest.WithOptions(ent.Log(t.Log)),
@@ -399,7 +398,7 @@ func TestEntHistory(t *testing.T) {
 		client := enttest.Open(t, "sqlite3", "file:entdb?_fk=1", opts...)
 		client.WithHistory()
 
-		err = client.Schema.Create(context.Background())
+		err := client.Schema.Create(context.Background())
 		assert.NoError(t, err)
 
 		defer func(client *ent.Client) {

--- a/_examples/enthistory_test.go
+++ b/_examples/enthistory_test.go
@@ -2,6 +2,7 @@ package _examples
 
 import (
 	"context"
+	"os"
 
 	"github.com/stretchr/testify/assert"
 
@@ -114,7 +115,7 @@ func TestEntHistory(t *testing.T) {
 				assert.NoError(t, err)
 
 				// create friendship
-				friendship, err := client.Friendship.Create().SetCharacterID(finn.ID).SetFriendID(jake.ID).Save(ctx)
+				friendship, err := client.Friendship.Create().SetID("brothers").SetCharacterID(finn.ID).SetFriendID(jake.ID).Save(ctx)
 				assert.NoError(t, err)
 				friendships, err := friendship.History().All(ctx)
 				assert.NoError(t, err)
@@ -360,7 +361,7 @@ func TestEntHistory(t *testing.T) {
 				simon, err := client.Character.Create().SetAge(47).SetName("Simon Petrikov").Save(ctx)
 				assert.NoError(t, err)
 
-				friendship, err := client.Friendship.Create().SetCharacterID(gunter.ID).SetFriendID(simon.ID).Save(ctx)
+				friendship, err := client.Friendship.Create().SetID("Ice Kingdom").SetCharacterID(gunter.ID).SetFriendID(simon.ID).Save(ctx)
 				assert.NoError(t, err)
 
 				gunter, err = gunter.Update().SetAge(20).Save(ctx)

--- a/hook.go
+++ b/hook.go
@@ -8,7 +8,6 @@ import (
 )
 
 type Mutation interface {
-	ID() (id int, exists bool)
 	Op() ent.Op
 	CreateHistoryFromCreate(ctx context.Context) error
 	CreateHistoryFromUpdate(ctx context.Context) error

--- a/schema.go
+++ b/schema.go
@@ -9,18 +9,17 @@ import (
 
 type history struct {
 	ent.Schema
+	ref ent.Field
 }
 
-func (history) Fields() []ent.Field {
+func (h history) Fields() []ent.Field {
 	return []ent.Field{
 		field.Time("history_time").
 			Default(time.Now).
 			Immutable(),
-		field.Int("ref").
-			Immutable().
-			Optional(),
 		field.Enum("operation").
 			GoType(OpType("")).
 			Immutable(),
+		h.ref,
 	}
 }

--- a/templates/auditing.tmpl
+++ b/templates/auditing.tmpl
@@ -201,7 +201,7 @@ func (c *Client) Audit(ctx context.Context) ([][]string, error) {
 
 type record struct {
 	Table       string
-	RefId       int
+	RefId       any
 	HistoryTime time.Time
 	Operation   enthistory.OpType
 	Changes     []Change
@@ -236,15 +236,21 @@ func (r *record) toRow() []string {
 	return row
 }
 
-type ref struct {
-	Ref int
-}
-
 {{- range $n := $.Nodes }}
 {{- if (hasSuffix $n.Name "History") }}
+
+{{- range $h := $.Nodes }}
+{{ $sameNodeType := hasPrefix $n.Name (printf "%sHistory" $h.Name) }}
+{{- if $sameNodeType }}
+type {{ lower $n.Name }}ref struct {
+	Ref {{ $h.ID.Type }}
+}
+{{- end }}
+{{- end }}
+
 func audit{{ $n.Name }}(ctx context.Context, config config) ([][]string, error) {
 	var records = [][]string{}
-	var refs []ref
+	var refs []{{ lower $n.Name }}ref
 	client := New{{ $n.Name }}Client(config)
 	err := client.Query().
 		Unique(true).

--- a/templates/schema.tmpl
+++ b/templates/schema.tmpl
@@ -42,7 +42,7 @@ func ({{ $name }}) Fields() []ent.Field {
         field.Time("history_time").
             Default(time.Now).
             Immutable(),
-        field.Int("ref").
+        field.{{ .IdType }}("ref").
             Immutable().
             Optional(),
         field.Enum("operation").
@@ -56,7 +56,15 @@ func ({{ $name }}) Fields() []ent.Field {
         {{- end }}
     }
 
-    return append(historyFields, {{ .OriginalTableName }}{}.Fields()...)
+
+    original := {{ .OriginalTableName }}{}
+    for _, field := range original.Fields() {
+        if field.Descriptor().Name != "id" {
+            historyFields = append(historyFields, field)
+        }
+    }
+
+    return historyFields
 }
 
 // Mixin of the {{ $name }}.

--- a/utils.go
+++ b/utils.go
@@ -27,8 +27,19 @@ func copyRef[T any](ref *T) *T {
 	return &val
 }
 
-func loadHistorySchema() (*load.Schema, error) {
-	bytes, err := load.MarshalSchema(history{})
+func loadHistorySchema(IdType string) (*load.Schema, error) {
+	schema := history{}
+
+	switch IdType {
+	case "int":
+		schema.ref = field.Int("ref").Immutable().Optional()
+	case "string":
+		schema.ref = field.String("ref").Immutable().Optional()
+	default:
+		return nil, errors.New("only id and string are supported id types right now")
+	}
+
+	bytes, err := load.MarshalSchema(schema)
 	if err != nil {
 		return nil, err
 	}
@@ -37,6 +48,7 @@ func loadHistorySchema() (*load.Schema, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return historySchema, nil
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow Id types on original models to be other types (string and int for now, can implement more as requested)

## Motivation and Context
Issue was brought up about a mismatched type on the mutation, the proposed issue doesn't seem to be the root cause of it but instead the use of a string ID

## How Has This Been Tested?
Updated example and tests to account for an id that is type string

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update or addition to documentation for this project)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
