### PR TITLE
Auditing fix for JSON fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,19 @@ generate:
 #    Run the tests
 test:
 	go test ./_examples/.
+
+validate-tag-arg:
+ifeq ("", "$(v)")
+	@echo "version arg (v) must be used with the 'tag' target"
+	@exit 1;
+endif
+ifneq ("v", "$(shell echo $(v) | head -c 1)")
+	@echo "version arg (v) must begin with v"
+	@exit 1;
+endif
+
+# ex: make tag v=v0.1.0
+tag: validate-tag-arg
+	@echo "creating tag $(v)"
+	git tag $(v)
+	git push origin $(v)

--- a/_examples/basic/ent/auditing.go
+++ b/_examples/basic/ent/auditing.go
@@ -8,41 +8,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/flume/enthistory"
 	"github.com/flume/enthistory/_examples/basic/ent/characterhistory"
 	"github.com/flume/enthistory/_examples/basic/ent/friendshiphistory"
 )
-
-// slicesEqual pulled from golang.org/x/exp to reduce direct dependencies required
-func slicesEqual[E comparable](s1, s2 []E) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-	for i := range s1 {
-		if s1[i] != s2[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// ptrsEqual check if two comparable pointers are equal
-func ptrsEqual[T comparable](ptr1, ptr2 *T) bool {
-	if ptr1 == nil || ptr2 == nil {
-		return ptr1 == ptr2
-	}
-	return *ptr1 == *ptr2
-}
-
-// ptrsEqual check if two time.Time pointers are equal
-func timePtrsEqual(ptr1, ptr2 *time.Time) bool {
-	if ptr1 == nil || ptr2 == nil {
-		return ptr1 == ptr2
-	}
-	return ptr1.Equal(*ptr2)
-}
 
 type Change struct {
 	FieldName string
@@ -71,22 +43,22 @@ var (
 
 func (ch *CharacterHistory) changes(new *CharacterHistory) []Change {
 	var changes []Change
-	if !ch.CreatedAt.Equal(new.CreatedAt) {
+	if !reflect.DeepEqual(ch.CreatedAt, new.CreatedAt) {
 		changes = append(changes, NewChange(characterhistory.FieldCreatedAt, ch.CreatedAt, new.CreatedAt))
 	}
-	if !ch.UpdatedAt.Equal(new.UpdatedAt) {
+	if !reflect.DeepEqual(ch.UpdatedAt, new.UpdatedAt) {
 		changes = append(changes, NewChange(characterhistory.FieldUpdatedAt, ch.UpdatedAt, new.UpdatedAt))
 	}
-	if ch.Age != new.Age {
+	if !reflect.DeepEqual(ch.Age, new.Age) {
 		changes = append(changes, NewChange(characterhistory.FieldAge, ch.Age, new.Age))
 	}
-	if ch.Name != new.Name {
+	if !reflect.DeepEqual(ch.Name, new.Name) {
 		changes = append(changes, NewChange(characterhistory.FieldName, ch.Name, new.Name))
 	}
-	if !slicesEqual(ch.Nicknames, new.Nicknames) {
+	if !reflect.DeepEqual(ch.Nicknames, new.Nicknames) {
 		changes = append(changes, NewChange(characterhistory.FieldNicknames, ch.Nicknames, new.Nicknames))
 	}
-	if ch.Info != new.Info {
+	if !reflect.DeepEqual(ch.Info, new.Info) {
 		changes = append(changes, NewChange(characterhistory.FieldInfo, ch.Info, new.Info))
 	}
 	return changes
@@ -119,16 +91,16 @@ func (ch *CharacterHistory) Diff(history *CharacterHistory) (*HistoryDiff[Charac
 
 func (fh *FriendshipHistory) changes(new *FriendshipHistory) []Change {
 	var changes []Change
-	if !fh.CreatedAt.Equal(new.CreatedAt) {
+	if !reflect.DeepEqual(fh.CreatedAt, new.CreatedAt) {
 		changes = append(changes, NewChange(friendshiphistory.FieldCreatedAt, fh.CreatedAt, new.CreatedAt))
 	}
-	if !fh.UpdatedAt.Equal(new.UpdatedAt) {
+	if !reflect.DeepEqual(fh.UpdatedAt, new.UpdatedAt) {
 		changes = append(changes, NewChange(friendshiphistory.FieldUpdatedAt, fh.UpdatedAt, new.UpdatedAt))
 	}
-	if fh.CharacterID != new.CharacterID {
+	if !reflect.DeepEqual(fh.CharacterID, new.CharacterID) {
 		changes = append(changes, NewChange(friendshiphistory.FieldCharacterID, fh.CharacterID, new.CharacterID))
 	}
-	if fh.FriendID != new.FriendID {
+	if !reflect.DeepEqual(fh.FriendID, new.FriendID) {
 		changes = append(changes, NewChange(friendshiphistory.FieldFriendID, fh.FriendID, new.FriendID))
 	}
 	return changes

--- a/_examples/basic/ent/auditing.go
+++ b/_examples/basic/ent/auditing.go
@@ -83,6 +83,12 @@ func (ch *CharacterHistory) changes(new *CharacterHistory) []Change {
 	if ch.Name != new.Name {
 		changes = append(changes, NewChange(characterhistory.FieldName, ch.Name, new.Name))
 	}
+	if !slicesEqual(ch.Nicknames, new.Nicknames) {
+		changes = append(changes, NewChange(characterhistory.FieldNicknames, ch.Nicknames, new.Nicknames))
+	}
+	if ch.Info != new.Info {
+		changes = append(changes, NewChange(characterhistory.FieldInfo, ch.Info, new.Info))
+	}
 	return changes
 }
 

--- a/_examples/basic/ent/character.go
+++ b/_examples/basic/ent/character.go
@@ -3,6 +3,7 @@
 package ent
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -26,6 +27,10 @@ type Character struct {
 	Age int `json:"age,omitempty"`
 	// Name holds the value of the "name" field.
 	Name string `json:"name,omitempty"`
+	// Nicknames holds the value of the "nicknames" field.
+	Nicknames []string `json:"nicknames,omitempty"`
+	// Info holds the value of the "info" field.
+	Info map[string]interface{} `json:"info,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the CharacterQuery when eager-loading is set.
 	Edges        CharacterEdges `json:"edges"`
@@ -66,6 +71,8 @@ func (*Character) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
+		case character.FieldNicknames, character.FieldInfo:
+			values[i] = new([]byte)
 		case character.FieldID, character.FieldAge:
 			values[i] = new(sql.NullInt64)
 		case character.FieldName:
@@ -116,6 +123,22 @@ func (c *Character) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field name", values[i])
 			} else if value.Valid {
 				c.Name = value.String
+			}
+		case character.FieldNicknames:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field nicknames", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &c.Nicknames); err != nil {
+					return fmt.Errorf("unmarshal field nicknames: %w", err)
+				}
+			}
+		case character.FieldInfo:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field info", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &c.Info); err != nil {
+					return fmt.Errorf("unmarshal field info: %w", err)
+				}
 			}
 		default:
 			c.selectValues.Set(columns[i], values[i])
@@ -174,6 +197,12 @@ func (c *Character) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("name=")
 	builder.WriteString(c.Name)
+	builder.WriteString(", ")
+	builder.WriteString("nicknames=")
+	builder.WriteString(fmt.Sprintf("%v", c.Nicknames))
+	builder.WriteString(", ")
+	builder.WriteString("info=")
+	builder.WriteString(fmt.Sprintf("%v", c.Info))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/_examples/basic/ent/character/character.go
+++ b/_examples/basic/ent/character/character.go
@@ -22,6 +22,10 @@ const (
 	FieldAge = "age"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
+	// FieldNicknames holds the string denoting the nicknames field in the database.
+	FieldNicknames = "nicknames"
+	// FieldInfo holds the string denoting the info field in the database.
+	FieldInfo = "info"
 	// EdgeFriends holds the string denoting the friends edge name in mutations.
 	EdgeFriends = "friends"
 	// EdgeFriendships holds the string denoting the friendships edge name in mutations.
@@ -46,6 +50,8 @@ var Columns = []string{
 	FieldUpdatedAt,
 	FieldAge,
 	FieldName,
+	FieldNicknames,
+	FieldInfo,
 }
 
 var (

--- a/_examples/basic/ent/character/where.go
+++ b/_examples/basic/ent/character/where.go
@@ -261,6 +261,26 @@ func NameContainsFold(v string) predicate.Character {
 	return predicate.Character(sql.FieldContainsFold(FieldName, v))
 }
 
+// NicknamesIsNil applies the IsNil predicate on the "nicknames" field.
+func NicknamesIsNil() predicate.Character {
+	return predicate.Character(sql.FieldIsNull(FieldNicknames))
+}
+
+// NicknamesNotNil applies the NotNil predicate on the "nicknames" field.
+func NicknamesNotNil() predicate.Character {
+	return predicate.Character(sql.FieldNotNull(FieldNicknames))
+}
+
+// InfoIsNil applies the IsNil predicate on the "info" field.
+func InfoIsNil() predicate.Character {
+	return predicate.Character(sql.FieldIsNull(FieldInfo))
+}
+
+// InfoNotNil applies the NotNil predicate on the "info" field.
+func InfoNotNil() predicate.Character {
+	return predicate.Character(sql.FieldNotNull(FieldInfo))
+}
+
 // HasFriends applies the HasEdge predicate on the "friends" edge.
 func HasFriends() predicate.Character {
 	return predicate.Character(func(s *sql.Selector) {

--- a/_examples/basic/ent/character_create.go
+++ b/_examples/basic/ent/character_create.go
@@ -62,6 +62,18 @@ func (cc *CharacterCreate) SetName(s string) *CharacterCreate {
 	return cc
 }
 
+// SetNicknames sets the "nicknames" field.
+func (cc *CharacterCreate) SetNicknames(s []string) *CharacterCreate {
+	cc.mutation.SetNicknames(s)
+	return cc
+}
+
+// SetInfo sets the "info" field.
+func (cc *CharacterCreate) SetInfo(m map[string]interface{}) *CharacterCreate {
+	cc.mutation.SetInfo(m)
+	return cc
+}
+
 // AddFriendIDs adds the "friends" edge to the Character entity by IDs.
 func (cc *CharacterCreate) AddFriendIDs(ids ...int) *CharacterCreate {
 	cc.mutation.AddFriendIDs(ids...)
@@ -197,6 +209,14 @@ func (cc *CharacterCreate) createSpec() (*Character, *sqlgraph.CreateSpec) {
 	if value, ok := cc.mutation.Name(); ok {
 		_spec.SetField(character.FieldName, field.TypeString, value)
 		_node.Name = value
+	}
+	if value, ok := cc.mutation.Nicknames(); ok {
+		_spec.SetField(character.FieldNicknames, field.TypeJSON, value)
+		_node.Nicknames = value
+	}
+	if value, ok := cc.mutation.Info(); ok {
+		_spec.SetField(character.FieldInfo, field.TypeJSON, value)
+		_node.Info = value
 	}
 	if nodes := cc.mutation.FriendsIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{

--- a/_examples/basic/ent/character_update.go
+++ b/_examples/basic/ent/character_update.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 
 	"github.com/flume/enthistory/_examples/basic/ent/character"
@@ -60,6 +61,36 @@ func (cu *CharacterUpdate) AddAge(i int) *CharacterUpdate {
 // SetName sets the "name" field.
 func (cu *CharacterUpdate) SetName(s string) *CharacterUpdate {
 	cu.mutation.SetName(s)
+	return cu
+}
+
+// SetNicknames sets the "nicknames" field.
+func (cu *CharacterUpdate) SetNicknames(s []string) *CharacterUpdate {
+	cu.mutation.SetNicknames(s)
+	return cu
+}
+
+// AppendNicknames appends s to the "nicknames" field.
+func (cu *CharacterUpdate) AppendNicknames(s []string) *CharacterUpdate {
+	cu.mutation.AppendNicknames(s)
+	return cu
+}
+
+// ClearNicknames clears the value of the "nicknames" field.
+func (cu *CharacterUpdate) ClearNicknames() *CharacterUpdate {
+	cu.mutation.ClearNicknames()
+	return cu
+}
+
+// SetInfo sets the "info" field.
+func (cu *CharacterUpdate) SetInfo(m map[string]interface{}) *CharacterUpdate {
+	cu.mutation.SetInfo(m)
+	return cu
+}
+
+// ClearInfo clears the value of the "info" field.
+func (cu *CharacterUpdate) ClearInfo() *CharacterUpdate {
+	cu.mutation.ClearInfo()
 	return cu
 }
 
@@ -200,6 +231,23 @@ func (cu *CharacterUpdate) sqlSave(ctx context.Context) (n int, err error) {
 	}
 	if value, ok := cu.mutation.Name(); ok {
 		_spec.SetField(character.FieldName, field.TypeString, value)
+	}
+	if value, ok := cu.mutation.Nicknames(); ok {
+		_spec.SetField(character.FieldNicknames, field.TypeJSON, value)
+	}
+	if value, ok := cu.mutation.AppendedNicknames(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, character.FieldNicknames, value)
+		})
+	}
+	if cu.mutation.NicknamesCleared() {
+		_spec.ClearField(character.FieldNicknames, field.TypeJSON)
+	}
+	if value, ok := cu.mutation.Info(); ok {
+		_spec.SetField(character.FieldInfo, field.TypeJSON, value)
+	}
+	if cu.mutation.InfoCleared() {
+		_spec.ClearField(character.FieldInfo, field.TypeJSON)
 	}
 	if cu.mutation.FriendsCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -353,6 +401,36 @@ func (cuo *CharacterUpdateOne) AddAge(i int) *CharacterUpdateOne {
 // SetName sets the "name" field.
 func (cuo *CharacterUpdateOne) SetName(s string) *CharacterUpdateOne {
 	cuo.mutation.SetName(s)
+	return cuo
+}
+
+// SetNicknames sets the "nicknames" field.
+func (cuo *CharacterUpdateOne) SetNicknames(s []string) *CharacterUpdateOne {
+	cuo.mutation.SetNicknames(s)
+	return cuo
+}
+
+// AppendNicknames appends s to the "nicknames" field.
+func (cuo *CharacterUpdateOne) AppendNicknames(s []string) *CharacterUpdateOne {
+	cuo.mutation.AppendNicknames(s)
+	return cuo
+}
+
+// ClearNicknames clears the value of the "nicknames" field.
+func (cuo *CharacterUpdateOne) ClearNicknames() *CharacterUpdateOne {
+	cuo.mutation.ClearNicknames()
+	return cuo
+}
+
+// SetInfo sets the "info" field.
+func (cuo *CharacterUpdateOne) SetInfo(m map[string]interface{}) *CharacterUpdateOne {
+	cuo.mutation.SetInfo(m)
+	return cuo
+}
+
+// ClearInfo clears the value of the "info" field.
+func (cuo *CharacterUpdateOne) ClearInfo() *CharacterUpdateOne {
+	cuo.mutation.ClearInfo()
 	return cuo
 }
 
@@ -523,6 +601,23 @@ func (cuo *CharacterUpdateOne) sqlSave(ctx context.Context) (_node *Character, e
 	}
 	if value, ok := cuo.mutation.Name(); ok {
 		_spec.SetField(character.FieldName, field.TypeString, value)
+	}
+	if value, ok := cuo.mutation.Nicknames(); ok {
+		_spec.SetField(character.FieldNicknames, field.TypeJSON, value)
+	}
+	if value, ok := cuo.mutation.AppendedNicknames(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, character.FieldNicknames, value)
+		})
+	}
+	if cuo.mutation.NicknamesCleared() {
+		_spec.ClearField(character.FieldNicknames, field.TypeJSON)
+	}
+	if value, ok := cuo.mutation.Info(); ok {
+		_spec.SetField(character.FieldInfo, field.TypeJSON, value)
+	}
+	if cuo.mutation.InfoCleared() {
+		_spec.ClearField(character.FieldInfo, field.TypeJSON)
 	}
 	if cuo.mutation.FriendsCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/_examples/basic/ent/characterhistory/characterhistory.go
+++ b/_examples/basic/ent/characterhistory/characterhistory.go
@@ -32,6 +32,10 @@ const (
 	FieldAge = "age"
 	// FieldName holds the string denoting the name field in the database.
 	FieldName = "name"
+	// FieldNicknames holds the string denoting the nicknames field in the database.
+	FieldNicknames = "nicknames"
+	// FieldInfo holds the string denoting the info field in the database.
+	FieldInfo = "info"
 	// Table holds the table name of the characterhistory in the database.
 	Table = "character_history"
 )
@@ -47,6 +51,8 @@ var Columns = []string{
 	FieldUpdatedAt,
 	FieldAge,
 	FieldName,
+	FieldNicknames,
+	FieldInfo,
 }
 
 // ValidColumn reports if the column name is valid (part of the table columns).

--- a/_examples/basic/ent/characterhistory/where.go
+++ b/_examples/basic/ent/characterhistory/where.go
@@ -436,6 +436,26 @@ func NameContainsFold(v string) predicate.CharacterHistory {
 	return predicate.CharacterHistory(sql.FieldContainsFold(FieldName, v))
 }
 
+// NicknamesIsNil applies the IsNil predicate on the "nicknames" field.
+func NicknamesIsNil() predicate.CharacterHistory {
+	return predicate.CharacterHistory(sql.FieldIsNull(FieldNicknames))
+}
+
+// NicknamesNotNil applies the NotNil predicate on the "nicknames" field.
+func NicknamesNotNil() predicate.CharacterHistory {
+	return predicate.CharacterHistory(sql.FieldNotNull(FieldNicknames))
+}
+
+// InfoIsNil applies the IsNil predicate on the "info" field.
+func InfoIsNil() predicate.CharacterHistory {
+	return predicate.CharacterHistory(sql.FieldIsNull(FieldInfo))
+}
+
+// InfoNotNil applies the NotNil predicate on the "info" field.
+func InfoNotNil() predicate.CharacterHistory {
+	return predicate.CharacterHistory(sql.FieldNotNull(FieldInfo))
+}
+
 // And groups predicates with the AND operator between them.
 func And(predicates ...predicate.CharacterHistory) predicate.CharacterHistory {
 	return predicate.CharacterHistory(func(s *sql.Selector) {

--- a/_examples/basic/ent/characterhistory_create.go
+++ b/_examples/basic/ent/characterhistory_create.go
@@ -110,6 +110,18 @@ func (chc *CharacterHistoryCreate) SetName(s string) *CharacterHistoryCreate {
 	return chc
 }
 
+// SetNicknames sets the "nicknames" field.
+func (chc *CharacterHistoryCreate) SetNicknames(s []string) *CharacterHistoryCreate {
+	chc.mutation.SetNicknames(s)
+	return chc
+}
+
+// SetInfo sets the "info" field.
+func (chc *CharacterHistoryCreate) SetInfo(m map[string]interface{}) *CharacterHistoryCreate {
+	chc.mutation.SetInfo(m)
+	return chc
+}
+
 // Mutation returns the CharacterHistoryMutation object of the builder.
 func (chc *CharacterHistoryCreate) Mutation() *CharacterHistoryMutation {
 	return chc.mutation
@@ -246,6 +258,14 @@ func (chc *CharacterHistoryCreate) createSpec() (*CharacterHistory, *sqlgraph.Cr
 	if value, ok := chc.mutation.Name(); ok {
 		_spec.SetField(characterhistory.FieldName, field.TypeString, value)
 		_node.Name = value
+	}
+	if value, ok := chc.mutation.Nicknames(); ok {
+		_spec.SetField(characterhistory.FieldNicknames, field.TypeJSON, value)
+		_node.Nicknames = value
+	}
+	if value, ok := chc.mutation.Info(); ok {
+		_spec.SetField(characterhistory.FieldInfo, field.TypeJSON, value)
+		_node.Info = value
 	}
 	return _node, _spec
 }

--- a/_examples/basic/ent/characterhistory_update.go
+++ b/_examples/basic/ent/characterhistory_update.go
@@ -10,6 +10,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
+	"entgo.io/ent/dialect/sql/sqljson"
 	"entgo.io/ent/schema/field"
 
 	"github.com/flume/enthistory/_examples/basic/ent/characterhistory"
@@ -59,6 +60,36 @@ func (chu *CharacterHistoryUpdate) AddAge(i int) *CharacterHistoryUpdate {
 // SetName sets the "name" field.
 func (chu *CharacterHistoryUpdate) SetName(s string) *CharacterHistoryUpdate {
 	chu.mutation.SetName(s)
+	return chu
+}
+
+// SetNicknames sets the "nicknames" field.
+func (chu *CharacterHistoryUpdate) SetNicknames(s []string) *CharacterHistoryUpdate {
+	chu.mutation.SetNicknames(s)
+	return chu
+}
+
+// AppendNicknames appends s to the "nicknames" field.
+func (chu *CharacterHistoryUpdate) AppendNicknames(s []string) *CharacterHistoryUpdate {
+	chu.mutation.AppendNicknames(s)
+	return chu
+}
+
+// ClearNicknames clears the value of the "nicknames" field.
+func (chu *CharacterHistoryUpdate) ClearNicknames() *CharacterHistoryUpdate {
+	chu.mutation.ClearNicknames()
+	return chu
+}
+
+// SetInfo sets the "info" field.
+func (chu *CharacterHistoryUpdate) SetInfo(m map[string]interface{}) *CharacterHistoryUpdate {
+	chu.mutation.SetInfo(m)
+	return chu
+}
+
+// ClearInfo clears the value of the "info" field.
+func (chu *CharacterHistoryUpdate) ClearInfo() *CharacterHistoryUpdate {
+	chu.mutation.ClearInfo()
 	return chu
 }
 
@@ -134,6 +165,23 @@ func (chu *CharacterHistoryUpdate) sqlSave(ctx context.Context) (n int, err erro
 	if value, ok := chu.mutation.Name(); ok {
 		_spec.SetField(characterhistory.FieldName, field.TypeString, value)
 	}
+	if value, ok := chu.mutation.Nicknames(); ok {
+		_spec.SetField(characterhistory.FieldNicknames, field.TypeJSON, value)
+	}
+	if value, ok := chu.mutation.AppendedNicknames(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, characterhistory.FieldNicknames, value)
+		})
+	}
+	if chu.mutation.NicknamesCleared() {
+		_spec.ClearField(characterhistory.FieldNicknames, field.TypeJSON)
+	}
+	if value, ok := chu.mutation.Info(); ok {
+		_spec.SetField(characterhistory.FieldInfo, field.TypeJSON, value)
+	}
+	if chu.mutation.InfoCleared() {
+		_spec.ClearField(characterhistory.FieldInfo, field.TypeJSON)
+	}
 	if n, err = sqlgraph.UpdateNodes(ctx, chu.driver, _spec); err != nil {
 		if _, ok := err.(*sqlgraph.NotFoundError); ok {
 			err = &NotFoundError{characterhistory.Label}
@@ -184,6 +232,36 @@ func (chuo *CharacterHistoryUpdateOne) AddAge(i int) *CharacterHistoryUpdateOne 
 // SetName sets the "name" field.
 func (chuo *CharacterHistoryUpdateOne) SetName(s string) *CharacterHistoryUpdateOne {
 	chuo.mutation.SetName(s)
+	return chuo
+}
+
+// SetNicknames sets the "nicknames" field.
+func (chuo *CharacterHistoryUpdateOne) SetNicknames(s []string) *CharacterHistoryUpdateOne {
+	chuo.mutation.SetNicknames(s)
+	return chuo
+}
+
+// AppendNicknames appends s to the "nicknames" field.
+func (chuo *CharacterHistoryUpdateOne) AppendNicknames(s []string) *CharacterHistoryUpdateOne {
+	chuo.mutation.AppendNicknames(s)
+	return chuo
+}
+
+// ClearNicknames clears the value of the "nicknames" field.
+func (chuo *CharacterHistoryUpdateOne) ClearNicknames() *CharacterHistoryUpdateOne {
+	chuo.mutation.ClearNicknames()
+	return chuo
+}
+
+// SetInfo sets the "info" field.
+func (chuo *CharacterHistoryUpdateOne) SetInfo(m map[string]interface{}) *CharacterHistoryUpdateOne {
+	chuo.mutation.SetInfo(m)
+	return chuo
+}
+
+// ClearInfo clears the value of the "info" field.
+func (chuo *CharacterHistoryUpdateOne) ClearInfo() *CharacterHistoryUpdateOne {
+	chuo.mutation.ClearInfo()
 	return chuo
 }
 
@@ -288,6 +366,23 @@ func (chuo *CharacterHistoryUpdateOne) sqlSave(ctx context.Context) (_node *Char
 	}
 	if value, ok := chuo.mutation.Name(); ok {
 		_spec.SetField(characterhistory.FieldName, field.TypeString, value)
+	}
+	if value, ok := chuo.mutation.Nicknames(); ok {
+		_spec.SetField(characterhistory.FieldNicknames, field.TypeJSON, value)
+	}
+	if value, ok := chuo.mutation.AppendedNicknames(); ok {
+		_spec.AddModifier(func(u *sql.UpdateBuilder) {
+			sqljson.Append(u, characterhistory.FieldNicknames, value)
+		})
+	}
+	if chuo.mutation.NicknamesCleared() {
+		_spec.ClearField(characterhistory.FieldNicknames, field.TypeJSON)
+	}
+	if value, ok := chuo.mutation.Info(); ok {
+		_spec.SetField(characterhistory.FieldInfo, field.TypeJSON, value)
+	}
+	if chuo.mutation.InfoCleared() {
+		_spec.ClearField(characterhistory.FieldInfo, field.TypeJSON)
 	}
 	_node = &CharacterHistory{config: chuo.config}
 	_spec.Assign = _node.assignValues

--- a/_examples/basic/ent/history_from_mutation.go
+++ b/_examples/basic/ent/history_from_mutation.go
@@ -82,6 +82,14 @@ func (m *CharacterMutation) CreateHistoryFromCreate(ctx context.Context) error {
 		create = create.SetName(name)
 	}
 
+	if nicknames, exists := m.Nicknames(); exists {
+		create = create.SetNicknames(nicknames)
+	}
+
+	if info, exists := m.Info(); exists {
+		create = create.SetInfo(info)
+	}
+
 	_, err = create.Save(ctx)
 	if err != nil {
 		rollback(tx, err)
@@ -144,6 +152,18 @@ func (m *CharacterMutation) CreateHistoryFromUpdate(ctx context.Context) error {
 		create = create.SetName(character.Name)
 	}
 
+	if nicknames, exists := m.Nicknames(); exists {
+		create = create.SetNicknames(nicknames)
+	} else {
+		create = create.SetNicknames(character.Nicknames)
+	}
+
+	if info, exists := m.Info(); exists {
+		create = create.SetInfo(info)
+	} else {
+		create = create.SetInfo(character.Info)
+	}
+
 	_, err = create.Save(ctx)
 	if err != nil {
 		rollback(tx, err)
@@ -186,6 +206,8 @@ func (m *CharacterMutation) CreateHistoryFromDelete(ctx context.Context) error {
 		SetUpdatedAt(character.UpdatedAt).
 		SetAge(character.Age).
 		SetName(character.Name).
+		SetNicknames(character.Nicknames).
+		SetInfo(character.Info).
 		Save(ctx)
 	if err != nil {
 		rollback(tx, err)

--- a/_examples/basic/ent/history_query.go
+++ b/_examples/basic/ent/history_query.go
@@ -66,6 +66,8 @@ func (ch *CharacterHistory) Restore(ctx context.Context) (*Character, error) {
 		SetUpdatedAt(ch.UpdatedAt).
 		SetAge(ch.Age).
 		SetName(ch.Name).
+		SetNicknames(ch.Nicknames).
+		SetInfo(ch.Info).
 		Save(ctx)
 }
 

--- a/_examples/basic/ent/migrate/schema.go
+++ b/_examples/basic/ent/migrate/schema.go
@@ -16,6 +16,8 @@ var (
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "age", Type: field.TypeInt},
 		{Name: "name", Type: field.TypeString},
+		{Name: "nicknames", Type: field.TypeJSON, Nullable: true},
+		{Name: "info", Type: field.TypeJSON, Nullable: true},
 	}
 	// CharacterTable holds the schema information for the "character" table.
 	CharacterTable = &schema.Table{
@@ -34,6 +36,8 @@ var (
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "age", Type: field.TypeInt},
 		{Name: "name", Type: field.TypeString},
+		{Name: "nicknames", Type: field.TypeJSON, Nullable: true},
+		{Name: "info", Type: field.TypeJSON, Nullable: true},
 	}
 	// CharacterHistoryTable holds the schema information for the "character_history" table.
 	CharacterHistoryTable = &schema.Table{

--- a/_examples/basic/ent/mutation.go
+++ b/_examples/basic/ent/mutation.go
@@ -46,6 +46,9 @@ type CharacterMutation struct {
 	age                *int
 	addage             *int
 	name               *string
+	nicknames          *[]string
+	appendnicknames    []string
+	info               *map[string]interface{}
 	clearedFields      map[string]struct{}
 	friends            map[int]struct{}
 	removedfriends     map[int]struct{}
@@ -320,6 +323,120 @@ func (m *CharacterMutation) ResetName() {
 	m.name = nil
 }
 
+// SetNicknames sets the "nicknames" field.
+func (m *CharacterMutation) SetNicknames(s []string) {
+	m.nicknames = &s
+	m.appendnicknames = nil
+}
+
+// Nicknames returns the value of the "nicknames" field in the mutation.
+func (m *CharacterMutation) Nicknames() (r []string, exists bool) {
+	v := m.nicknames
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldNicknames returns the old "nicknames" field's value of the Character entity.
+// If the Character object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CharacterMutation) OldNicknames(ctx context.Context) (v []string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldNicknames is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldNicknames requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldNicknames: %w", err)
+	}
+	return oldValue.Nicknames, nil
+}
+
+// AppendNicknames adds s to the "nicknames" field.
+func (m *CharacterMutation) AppendNicknames(s []string) {
+	m.appendnicknames = append(m.appendnicknames, s...)
+}
+
+// AppendedNicknames returns the list of values that were appended to the "nicknames" field in this mutation.
+func (m *CharacterMutation) AppendedNicknames() ([]string, bool) {
+	if len(m.appendnicknames) == 0 {
+		return nil, false
+	}
+	return m.appendnicknames, true
+}
+
+// ClearNicknames clears the value of the "nicknames" field.
+func (m *CharacterMutation) ClearNicknames() {
+	m.nicknames = nil
+	m.appendnicknames = nil
+	m.clearedFields[character.FieldNicknames] = struct{}{}
+}
+
+// NicknamesCleared returns if the "nicknames" field was cleared in this mutation.
+func (m *CharacterMutation) NicknamesCleared() bool {
+	_, ok := m.clearedFields[character.FieldNicknames]
+	return ok
+}
+
+// ResetNicknames resets all changes to the "nicknames" field.
+func (m *CharacterMutation) ResetNicknames() {
+	m.nicknames = nil
+	m.appendnicknames = nil
+	delete(m.clearedFields, character.FieldNicknames)
+}
+
+// SetInfo sets the "info" field.
+func (m *CharacterMutation) SetInfo(value map[string]interface{}) {
+	m.info = &value
+}
+
+// Info returns the value of the "info" field in the mutation.
+func (m *CharacterMutation) Info() (r map[string]interface{}, exists bool) {
+	v := m.info
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldInfo returns the old "info" field's value of the Character entity.
+// If the Character object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CharacterMutation) OldInfo(ctx context.Context) (v map[string]interface{}, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldInfo is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldInfo requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldInfo: %w", err)
+	}
+	return oldValue.Info, nil
+}
+
+// ClearInfo clears the value of the "info" field.
+func (m *CharacterMutation) ClearInfo() {
+	m.info = nil
+	m.clearedFields[character.FieldInfo] = struct{}{}
+}
+
+// InfoCleared returns if the "info" field was cleared in this mutation.
+func (m *CharacterMutation) InfoCleared() bool {
+	_, ok := m.clearedFields[character.FieldInfo]
+	return ok
+}
+
+// ResetInfo resets all changes to the "info" field.
+func (m *CharacterMutation) ResetInfo() {
+	m.info = nil
+	delete(m.clearedFields, character.FieldInfo)
+}
+
 // AddFriendIDs adds the "friends" edge to the Character entity by ids.
 func (m *CharacterMutation) AddFriendIDs(ids ...int) {
 	if m.friends == nil {
@@ -462,7 +579,7 @@ func (m *CharacterMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CharacterMutation) Fields() []string {
-	fields := make([]string, 0, 4)
+	fields := make([]string, 0, 6)
 	if m.created_at != nil {
 		fields = append(fields, character.FieldCreatedAt)
 	}
@@ -474,6 +591,12 @@ func (m *CharacterMutation) Fields() []string {
 	}
 	if m.name != nil {
 		fields = append(fields, character.FieldName)
+	}
+	if m.nicknames != nil {
+		fields = append(fields, character.FieldNicknames)
+	}
+	if m.info != nil {
+		fields = append(fields, character.FieldInfo)
 	}
 	return fields
 }
@@ -491,6 +614,10 @@ func (m *CharacterMutation) Field(name string) (ent.Value, bool) {
 		return m.Age()
 	case character.FieldName:
 		return m.Name()
+	case character.FieldNicknames:
+		return m.Nicknames()
+	case character.FieldInfo:
+		return m.Info()
 	}
 	return nil, false
 }
@@ -508,6 +635,10 @@ func (m *CharacterMutation) OldField(ctx context.Context, name string) (ent.Valu
 		return m.OldAge(ctx)
 	case character.FieldName:
 		return m.OldName(ctx)
+	case character.FieldNicknames:
+		return m.OldNicknames(ctx)
+	case character.FieldInfo:
+		return m.OldInfo(ctx)
 	}
 	return nil, fmt.Errorf("unknown Character field %s", name)
 }
@@ -544,6 +675,20 @@ func (m *CharacterMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetName(v)
+		return nil
+	case character.FieldNicknames:
+		v, ok := value.([]string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetNicknames(v)
+		return nil
+	case character.FieldInfo:
+		v, ok := value.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetInfo(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Character field %s", name)
@@ -589,7 +734,14 @@ func (m *CharacterMutation) AddField(name string, value ent.Value) error {
 // ClearedFields returns all nullable fields that were cleared during this
 // mutation.
 func (m *CharacterMutation) ClearedFields() []string {
-	return nil
+	var fields []string
+	if m.FieldCleared(character.FieldNicknames) {
+		fields = append(fields, character.FieldNicknames)
+	}
+	if m.FieldCleared(character.FieldInfo) {
+		fields = append(fields, character.FieldInfo)
+	}
+	return fields
 }
 
 // FieldCleared returns a boolean indicating if a field with the given name was
@@ -602,6 +754,14 @@ func (m *CharacterMutation) FieldCleared(name string) bool {
 // ClearField clears the value of the field with the given name. It returns an
 // error if the field is not defined in the schema.
 func (m *CharacterMutation) ClearField(name string) error {
+	switch name {
+	case character.FieldNicknames:
+		m.ClearNicknames()
+		return nil
+	case character.FieldInfo:
+		m.ClearInfo()
+		return nil
+	}
 	return fmt.Errorf("unknown Character nullable field %s", name)
 }
 
@@ -620,6 +780,12 @@ func (m *CharacterMutation) ResetField(name string) error {
 		return nil
 	case character.FieldName:
 		m.ResetName()
+		return nil
+	case character.FieldNicknames:
+		m.ResetNicknames()
+		return nil
+	case character.FieldInfo:
+		m.ResetInfo()
 		return nil
 	}
 	return fmt.Errorf("unknown Character field %s", name)
@@ -738,24 +904,27 @@ func (m *CharacterMutation) ResetEdge(name string) error {
 // CharacterHistoryMutation represents an operation that mutates the CharacterHistory nodes in the graph.
 type CharacterHistoryMutation struct {
 	config
-	op            Op
-	typ           string
-	id            *int
-	history_time  *time.Time
-	operation     *enthistory.OpType
-	ref           *int
-	addref        *int
-	updated_by    *int
-	addupdated_by *int
-	created_at    *time.Time
-	updated_at    *time.Time
-	age           *int
-	addage        *int
-	name          *string
-	clearedFields map[string]struct{}
-	done          bool
-	oldValue      func(context.Context) (*CharacterHistory, error)
-	predicates    []predicate.CharacterHistory
+	op              Op
+	typ             string
+	id              *int
+	history_time    *time.Time
+	operation       *enthistory.OpType
+	ref             *int
+	addref          *int
+	updated_by      *int
+	addupdated_by   *int
+	created_at      *time.Time
+	updated_at      *time.Time
+	age             *int
+	addage          *int
+	name            *string
+	nicknames       *[]string
+	appendnicknames []string
+	info            *map[string]interface{}
+	clearedFields   map[string]struct{}
+	done            bool
+	oldValue        func(context.Context) (*CharacterHistory, error)
+	predicates      []predicate.CharacterHistory
 }
 
 var _ ent.Mutation = (*CharacterHistoryMutation)(nil)
@@ -1232,6 +1401,120 @@ func (m *CharacterHistoryMutation) ResetName() {
 	m.name = nil
 }
 
+// SetNicknames sets the "nicknames" field.
+func (m *CharacterHistoryMutation) SetNicknames(s []string) {
+	m.nicknames = &s
+	m.appendnicknames = nil
+}
+
+// Nicknames returns the value of the "nicknames" field in the mutation.
+func (m *CharacterHistoryMutation) Nicknames() (r []string, exists bool) {
+	v := m.nicknames
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldNicknames returns the old "nicknames" field's value of the CharacterHistory entity.
+// If the CharacterHistory object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CharacterHistoryMutation) OldNicknames(ctx context.Context) (v []string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldNicknames is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldNicknames requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldNicknames: %w", err)
+	}
+	return oldValue.Nicknames, nil
+}
+
+// AppendNicknames adds s to the "nicknames" field.
+func (m *CharacterHistoryMutation) AppendNicknames(s []string) {
+	m.appendnicknames = append(m.appendnicknames, s...)
+}
+
+// AppendedNicknames returns the list of values that were appended to the "nicknames" field in this mutation.
+func (m *CharacterHistoryMutation) AppendedNicknames() ([]string, bool) {
+	if len(m.appendnicknames) == 0 {
+		return nil, false
+	}
+	return m.appendnicknames, true
+}
+
+// ClearNicknames clears the value of the "nicknames" field.
+func (m *CharacterHistoryMutation) ClearNicknames() {
+	m.nicknames = nil
+	m.appendnicknames = nil
+	m.clearedFields[characterhistory.FieldNicknames] = struct{}{}
+}
+
+// NicknamesCleared returns if the "nicknames" field was cleared in this mutation.
+func (m *CharacterHistoryMutation) NicknamesCleared() bool {
+	_, ok := m.clearedFields[characterhistory.FieldNicknames]
+	return ok
+}
+
+// ResetNicknames resets all changes to the "nicknames" field.
+func (m *CharacterHistoryMutation) ResetNicknames() {
+	m.nicknames = nil
+	m.appendnicknames = nil
+	delete(m.clearedFields, characterhistory.FieldNicknames)
+}
+
+// SetInfo sets the "info" field.
+func (m *CharacterHistoryMutation) SetInfo(value map[string]interface{}) {
+	m.info = &value
+}
+
+// Info returns the value of the "info" field in the mutation.
+func (m *CharacterHistoryMutation) Info() (r map[string]interface{}, exists bool) {
+	v := m.info
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldInfo returns the old "info" field's value of the CharacterHistory entity.
+// If the CharacterHistory object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *CharacterHistoryMutation) OldInfo(ctx context.Context) (v map[string]interface{}, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldInfo is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldInfo requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldInfo: %w", err)
+	}
+	return oldValue.Info, nil
+}
+
+// ClearInfo clears the value of the "info" field.
+func (m *CharacterHistoryMutation) ClearInfo() {
+	m.info = nil
+	m.clearedFields[characterhistory.FieldInfo] = struct{}{}
+}
+
+// InfoCleared returns if the "info" field was cleared in this mutation.
+func (m *CharacterHistoryMutation) InfoCleared() bool {
+	_, ok := m.clearedFields[characterhistory.FieldInfo]
+	return ok
+}
+
+// ResetInfo resets all changes to the "info" field.
+func (m *CharacterHistoryMutation) ResetInfo() {
+	m.info = nil
+	delete(m.clearedFields, characterhistory.FieldInfo)
+}
+
 // Where appends a list predicates to the CharacterHistoryMutation builder.
 func (m *CharacterHistoryMutation) Where(ps ...predicate.CharacterHistory) {
 	m.predicates = append(m.predicates, ps...)
@@ -1266,7 +1549,7 @@ func (m *CharacterHistoryMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *CharacterHistoryMutation) Fields() []string {
-	fields := make([]string, 0, 8)
+	fields := make([]string, 0, 10)
 	if m.history_time != nil {
 		fields = append(fields, characterhistory.FieldHistoryTime)
 	}
@@ -1290,6 +1573,12 @@ func (m *CharacterHistoryMutation) Fields() []string {
 	}
 	if m.name != nil {
 		fields = append(fields, characterhistory.FieldName)
+	}
+	if m.nicknames != nil {
+		fields = append(fields, characterhistory.FieldNicknames)
+	}
+	if m.info != nil {
+		fields = append(fields, characterhistory.FieldInfo)
 	}
 	return fields
 }
@@ -1315,6 +1604,10 @@ func (m *CharacterHistoryMutation) Field(name string) (ent.Value, bool) {
 		return m.Age()
 	case characterhistory.FieldName:
 		return m.Name()
+	case characterhistory.FieldNicknames:
+		return m.Nicknames()
+	case characterhistory.FieldInfo:
+		return m.Info()
 	}
 	return nil, false
 }
@@ -1340,6 +1633,10 @@ func (m *CharacterHistoryMutation) OldField(ctx context.Context, name string) (e
 		return m.OldAge(ctx)
 	case characterhistory.FieldName:
 		return m.OldName(ctx)
+	case characterhistory.FieldNicknames:
+		return m.OldNicknames(ctx)
+	case characterhistory.FieldInfo:
+		return m.OldInfo(ctx)
 	}
 	return nil, fmt.Errorf("unknown CharacterHistory field %s", name)
 }
@@ -1404,6 +1701,20 @@ func (m *CharacterHistoryMutation) SetField(name string, value ent.Value) error 
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetName(v)
+		return nil
+	case characterhistory.FieldNicknames:
+		v, ok := value.([]string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetNicknames(v)
+		return nil
+	case characterhistory.FieldInfo:
+		v, ok := value.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetInfo(v)
 		return nil
 	}
 	return fmt.Errorf("unknown CharacterHistory field %s", name)
@@ -1480,6 +1791,12 @@ func (m *CharacterHistoryMutation) ClearedFields() []string {
 	if m.FieldCleared(characterhistory.FieldUpdatedBy) {
 		fields = append(fields, characterhistory.FieldUpdatedBy)
 	}
+	if m.FieldCleared(characterhistory.FieldNicknames) {
+		fields = append(fields, characterhistory.FieldNicknames)
+	}
+	if m.FieldCleared(characterhistory.FieldInfo) {
+		fields = append(fields, characterhistory.FieldInfo)
+	}
 	return fields
 }
 
@@ -1499,6 +1816,12 @@ func (m *CharacterHistoryMutation) ClearField(name string) error {
 		return nil
 	case characterhistory.FieldUpdatedBy:
 		m.ClearUpdatedBy()
+		return nil
+	case characterhistory.FieldNicknames:
+		m.ClearNicknames()
+		return nil
+	case characterhistory.FieldInfo:
+		m.ClearInfo()
 		return nil
 	}
 	return fmt.Errorf("unknown CharacterHistory nullable field %s", name)
@@ -1531,6 +1854,12 @@ func (m *CharacterHistoryMutation) ResetField(name string) error {
 		return nil
 	case characterhistory.FieldName:
 		m.ResetName()
+		return nil
+	case characterhistory.FieldNicknames:
+		m.ResetNicknames()
+		return nil
+	case characterhistory.FieldInfo:
+		m.ResetInfo()
 		return nil
 	}
 	return fmt.Errorf("unknown CharacterHistory field %s", name)

--- a/_examples/basic/ent/schema/character.go
+++ b/_examples/basic/ent/schema/character.go
@@ -30,6 +30,10 @@ func (Character) Fields() []ent.Field {
 		field.Int("age").
 			Positive(),
 		field.String("name"),
+		field.JSON("nicknames", []string{}).
+			Optional(),
+		field.JSON("info", map[string]any{}).
+			Optional(),
 	}
 }
 

--- a/_examples/enthistory_test.go
+++ b/_examples/enthistory_test.go
@@ -356,17 +356,36 @@ func TestEntHistory(t *testing.T) {
 				userId := 75
 				ctx := context.WithValue(context.Background(), "userId", userId)
 
-				gunter, err := client.Character.Create().SetAge(10000).SetName("Gunter").Save(ctx)
+				gunter, err := client.Character.Create().
+					SetAge(10000).
+					SetName("Gunter").
+					SetNicknames([]string{"Orgalorg"}).
+					Save(ctx)
 				assert.NoError(t, err)
-				simon, err := client.Character.Create().SetAge(47).SetName("Simon Petrikov").Save(ctx)
+				simon, err := client.Character.Create().
+					SetAge(47).
+					SetName("Simon Petrikov").
+					SetInfo(map[string]any{
+						"firstAppearance": "Come Along With Me",
+					}).
+					Save(ctx)
 				assert.NoError(t, err)
 
 				friendship, err := client.Friendship.Create().SetID("Ice Kingdom").SetCharacterID(gunter.ID).SetFriendID(simon.ID).Save(ctx)
 				assert.NoError(t, err)
 
-				gunter, err = gunter.Update().SetAge(20).Save(ctx)
+				gunter, err = gunter.Update().
+					SetNicknames([]string{"Orgalorg", "Destroyer of Worlds"}).
+					SetAge(20).
+					Save(ctx)
 				assert.NoError(t, err)
-				simon, err = simon.Update().SetName("Ice King").Save(ctx)
+				simon, err = simon.Update().
+					SetName("Ice King").
+					SetInfo(map[string]any{
+						"firstAppearance": "Come Along With Me",
+						"lastAppearance":  "Together Again",
+					}).
+					Save(ctx)
 				assert.NoError(t, err)
 
 				err = client.Friendship.DeleteOne(friendship).Exec(ctx)

--- a/_examples/enthistory_test.go
+++ b/_examples/enthistory_test.go
@@ -402,7 +402,8 @@ func TestEntHistory(t *testing.T) {
 
 				assert.Equal(t, 9, len(auditTable))
 				assert.Equal(t, 6, len(auditTable[0]))
-				assert.Equal(t, "age: 10000 -> 20", auditTable[2][4])
+				assert.Equal(t, "age: 10000 -> 20\nnicknames: [\"Orgalorg\"] -> [\"Orgalorg\",\"Destroyer of Worlds\"]", auditTable[2][4])
+				assert.Equal(t, "name: \"Simon Petrikov\" -> \"Ice King\"\ninfo: {\"firstAppearance\":\"Come Along With Me\"} -> {\"firstAppearance\":\"Come Along With Me\",\"lastAppearance\":\"Together Again\"}", auditTable[5][4])
 			},
 		},
 	}

--- a/templates/auditing.tmpl
+++ b/templates/auditing.tmpl
@@ -9,6 +9,7 @@ import (
     "encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/flume/enthistory"
@@ -24,35 +25,6 @@ import (
 
 {{ $updatedByKey := extractUpdatedByKey $.Annotations.HistoryConfig.UpdatedBy }}
 {{ $updatedByValueType := extractUpdatedByValueType $.Annotations.HistoryConfig.UpdatedBy }}
-
-// slicesEqual pulled from golang.org/x/exp to reduce direct dependencies required
-func slicesEqual[E comparable](s1, s2 []E) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-	for i := range s1 {
-		if s1[i] != s2[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// ptrsEqual check if two comparable pointers are equal
-func ptrsEqual[T comparable](ptr1, ptr2 *T) bool {
-	if ptr1 == nil || ptr2 == nil {
-		return ptr1 == ptr2
-	}
-	return *ptr1 == *ptr2
-}
-
-// ptrsEqual check if two time.Time pointers are equal
-func timePtrsEqual(ptr1, ptr2 *time.Time) bool {
-	if ptr1 == nil || ptr2 == nil {
-		return ptr1 == ptr2
-	}
-	return ptr1.Equal(*ptr2)
-}
 
 type Change struct {
     FieldName string
@@ -92,31 +64,9 @@ func ({{ $h.Receiver }} *{{ $h.Name }}) changes(new *{{ $h.Name }}) []Change {
     var changes []Change
 {{- range $f := $h.Fields }}
     {{- if not (in $f.StructField (slist "Ref" "HistoryTime" "Operation" "UpdatedBy")) }}
-        {{- if $f.Nillable }}
-            {{- if (eq $f.Type.String "time.Time") }}
-                if !timePtrsEqual({{ $h.Receiver }}.{{ $f.StructField }}, new.{{ $f.StructField }}) {
-                    changes = append(changes, NewChange({{ lower $h.Name }}.Field{{ $f.StructField }} , {{ $h.Receiver }}.{{ $f.StructField }}, new.{{ $f.StructField }}))
-                }
-            {{- else }}
-                if !ptrsEqual({{ $h.Receiver }}.{{ $f.StructField }}, new.{{ $f.StructField }}) {
-                    changes = append(changes, NewChange({{ lower $h.Name }}.Field{{ $f.StructField }} , {{ $h.Receiver }}.{{ $f.StructField }}, new.{{ $f.StructField }}))
-                }
-            {{- end }}
-        {{- else }}
-            {{- if (isSlice $f.Type.String) }}
-                if !slicesEqual({{ $h.Receiver }}.{{ $f.StructField }}, new.{{ $f.StructField }}) {
-                    changes = append(changes, NewChange({{ lower $h.Name }}.Field{{ $f.StructField }} , {{ $h.Receiver }}.{{ $f.StructField }}, new.{{ $f.StructField }}))
-                }
-            {{- else if (eq $f.Type.String "time.Time") }}
-                if !{{ $h.Receiver }}.{{ $f.StructField }}.Equal(new.{{ $f.StructField }}) {
-                    changes = append(changes, NewChange({{ lower $h.Name }}.Field{{ $f.StructField }} , {{ $h.Receiver }}.{{ $f.StructField }}, new.{{ $f.StructField }}))
-                }
-            {{- else }}
-                if {{ $h.Receiver }}.{{ $f.StructField }} != new.{{ $f.StructField }} {
-                    changes = append(changes, NewChange({{ lower $h.Name }}.Field{{ $f.StructField }} , {{ $h.Receiver }}.{{ $f.StructField }}, new.{{ $f.StructField }}))
-                }
-            {{- end }}
-        {{- end }}
+        if !reflect.DeepEqual({{ $h.Receiver }}.{{ $f.StructField }}, new.{{ $f.StructField }}) {
+            changes = append(changes, NewChange({{ lower $h.Name }}.Field{{ $f.StructField }} , {{ $h.Receiver }}.{{ $f.StructField }}, new.{{ $f.StructField }}))
+        }
     {{- end }}
 {{- end }}
     return changes


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Simplifies the equality check for diffing the rows in for generating audits, relies on `reflect.DeepEqual` instead of custom type specific checks

## Motivation and Context
Issue #19 

## How Has This Been Tested?
Updated tests with example of a concrete json type and a map[string]any type

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update or addition to documentation for this project)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
