### PR TITLE
Mutation IDs for Update and Delete

### DIFF
--- a/_examples/enthistory_test.go
+++ b/_examples/enthistory_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 
+	entcharacter "github.com/flume/enthistory/_examples/basic/ent/character"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/flume/enthistory/_examples/basic/ent/characterhistory"
@@ -69,6 +71,27 @@ func TestEntHistory(t *testing.T) {
 				assert.NoError(t, err)
 				// delete
 				err = client.Character.DeleteOne(character).Exec(ctx)
+				assert.NoError(t, err)
+				characterHistory, err := character.History().All(ctx)
+				assert.NoError(t, err)
+				assert.Equal(t, 3, len(characterHistory))
+				allHistory, err := client.CharacterHistory.Query().All(ctx)
+				assert.NoError(t, err)
+				assert.Equal(t, 3, len(allHistory))
+			},
+		},
+		{
+			name: "Handles 1 character delete by name",
+			runner: func(t *testing.T, client *ent.Client) {
+				ctx := context.Background()
+				// create
+				character, err := client.Character.Create().SetAge(1003).SetName("Marceline").Save(ctx)
+				assert.NoError(t, err)
+				// update
+				character, err = character.Update().SetName("Marceline the Vampire Queen").Save(ctx)
+				assert.NoError(t, err)
+				// delete
+				_, err = client.Character.Delete().Where(entcharacter.NameEQ(character.Name)).Exec(ctx)
 				assert.NoError(t, err)
 				characterHistory, err := character.History().All(ctx)
 				assert.NoError(t, err)

--- a/templates/historyFromMutation.tmpl
+++ b/templates/historyFromMutation.tmpl
@@ -97,47 +97,50 @@
                         updatedBy, _ := ctx.Value("{{ $updatedByKey }}").({{ $updatedByValueType }})
                         {{ end }}
 
-                        id, ok := m.ID()
-                        if !ok {
-                            return rollback(tx, idNotFoundError)
-                        }
-
-                        {{ camel $name }}, err := client.{{ $name }}.Get(ctx, id)
+                        ids, err := m.IDs(ctx)
                         if err != nil {
-                            return rollback(tx, err)
+                            return rollback(tx, fmt.Errorf("getting ids: %w", err))
                         }
 
-                        create := client.{{$h.Name}}.Create()
-                        if tx != nil {
-                            create = tx.{{$h.Name}}.Create()
-                        }
-                        create = create.
-                            SetOperation(EntOpToHistoryOp(m.Op())).
-                            SetHistoryTime(time.Now()).
-                            SetRef(id)
-
-                        {{- if not (eq $updatedByKey "") }}
-                            {{- if (eq $updatedByValueType "int") }}
-                            if updatedBy != 0 {
-                            {{- end }}
-                            {{- if (eq $updatedByValueType "string") }}
-                            if updatedBy != "" {
-                            {{- end }}
-                                create = create.SetUpdatedBy(updatedBy)
+                        for _, id := range ids {
+                            {{ camel $name }}, err := client.{{ $name }}.Get(ctx, id)
+                            if err != nil {
+                                return rollback(tx, err)
                             }
-                        {{- end }}
 
-                    {{ range $f := $n.Fields }}
-                        if {{ camel $f.Name }}, exists := m.{{ $f.StructField }}(); exists {
-                            create = create.Set{{ if $f.Nillable }}Nillable{{ end }}{{ $f.StructField }}({{ if $f.Nillable }}&{{ end }}{{ camel $f.Name }})
-                        } else {
-                            create = create.Set{{ if $f.Nillable }}Nillable{{ end }}{{ $f.StructField }}({{ camel $name }}.{{ pascal $f.Name }})
+                            create := client.{{$h.Name}}.Create()
+                            if tx != nil {
+                                create = tx.{{$h.Name}}.Create()
+                            }
+                            create = create.
+                                SetOperation(EntOpToHistoryOp(m.Op())).
+                                SetHistoryTime(time.Now()).
+                                SetRef(id)
+
+                            {{- if not (eq $updatedByKey "") }}
+                                {{- if (eq $updatedByValueType "int") }}
+                                if updatedBy != 0 {
+                                {{- end }}
+                                {{- if (eq $updatedByValueType "string") }}
+                                if updatedBy != "" {
+                                {{- end }}
+                                    create = create.SetUpdatedBy(updatedBy)
+                                }
+                            {{- end }}
+
+                        {{ range $f := $n.Fields }}
+                            if {{ camel $f.Name }}, exists := m.{{ $f.StructField }}(); exists {
+                                create = create.Set{{ if $f.Nillable }}Nillable{{ end }}{{ $f.StructField }}({{ if $f.Nillable }}&{{ end }}{{ camel $f.Name }})
+                            } else {
+                                create = create.Set{{ if $f.Nillable }}Nillable{{ end }}{{ $f.StructField }}({{ camel $name }}.{{ pascal $f.Name }})
+                            }
+                        {{ end }}
+                            _, err = create.Save(ctx)
+                            if err != nil {
+                                rollback(tx, err)
+                            }
                         }
-                    {{ end }}
-                        _, err = create.Save(ctx)
-                        if err != nil {
-                            rollback(tx, err)
-                        }
+
                         return nil
                     }
 
@@ -152,43 +155,46 @@
                         updatedBy, _ := ctx.Value("{{ $updatedByKey }}").({{ $updatedByValueType }})
                         {{ end }}
 
-                        id, ok := m.ID()
-                        if !ok {
-                            return rollback(tx, idNotFoundError)
-                        }
-
-                        {{ camel $name }}, err := client.{{ $name }}.Get(ctx, id)
+                        ids, err := m.IDs(ctx)
                         if err != nil {
-                            return rollback(tx, err)
+                            return rollback(tx, fmt.Errorf("getting ids: %w", err))
                         }
 
-                        create := client.{{$h.Name}}.Create()
-                        if tx != nil {
-                            create = tx.{{$h.Name}}.Create()
-                        }
-
-                        {{- if not (eq $updatedByKey "") }}
-                            {{- if (eq $updatedByValueType "int") }}
-                            if updatedBy != 0 {
-                            {{- end }}
-                            {{- if (eq $updatedByValueType "string") }}
-                            if updatedBy != "" {
-                            {{- end }}
-                                create = create.SetUpdatedBy(updatedBy)
+                        for _, id := range ids {
+                            {{ camel $name }}, err := client.{{ $name }}.Get(ctx, id)
+                            if err != nil {
+                                return rollback(tx, err)
                             }
-                        {{- end }}
 
-                        _, err = create.
-                            SetOperation(EntOpToHistoryOp(m.Op())).
-                            SetHistoryTime(time.Now()).
-                            SetRef(id).
-                        {{- range $f := $n.Fields }}
-                            Set{{ if $f.Nillable }}Nillable{{ end }}{{ $f.StructField }}({{ camel $name }}.{{ pascal $f.Name }}).
-                        {{- end }}
-                            Save(ctx)
-                        if err != nil {
-                            rollback(tx, err)
+                            create := client.{{$h.Name}}.Create()
+                            if tx != nil {
+                                create = tx.{{$h.Name}}.Create()
+                            }
+
+                            {{- if not (eq $updatedByKey "") }}
+                                {{- if (eq $updatedByValueType "int") }}
+                                if updatedBy != 0 {
+                                {{- end }}
+                                {{- if (eq $updatedByValueType "string") }}
+                                if updatedBy != "" {
+                                {{- end }}
+                                    create = create.SetUpdatedBy(updatedBy)
+                                }
+                            {{- end }}
+
+                            _, err = create.
+                                SetOperation(EntOpToHistoryOp(m.Op())).
+                                SetHistoryTime(time.Now()).
+                                SetRef(id).
+                            {{- range $f := $n.Fields }}
+                                Set{{ if $f.Nillable }}Nillable{{ end }}{{ $f.StructField }}({{ camel $name }}.{{ pascal $f.Name }}).
+                            {{- end }}
+                                Save(ctx)
+                            if err != nil {
+                                rollback(tx, err)
+                            }
                         }
+
                         return nil
                     }
                 {{ end }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In update and delete hook functions, get the mutation IDs instead of a singular ID

## Motivation and Context
A bug was discovered when updating or deleting multiple records at a time that caused enthistory to fail. Ent provides the `IDs()` func on the mutation to collect the ids appropriately for this exact usecase.

## How Has This Been Tested?
Updated tests to first verify the bug then to verify the solution

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update or addition to documentation for this project)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
