### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -47,6 +47,8 @@ jobs:
   formatting:
     name: Formatting
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/flume/enthistory/security/code-scanning/3](https://github.com/flume/enthistory/security/code-scanning/3)

To resolve the issue, add an explicit `permissions` block to the `Formatting` job to restrict the `GITHUB_TOKEN` to read-only access. Since the job only reads repository contents to check formatting, `contents: read` is sufficient. The permissions block should be added at the job level (inside the `Formatting` job), so it applies specifically to that job without affecting others.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
