### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - "**" # Run on all branches
 
+permissions:
+  contents: read
+
 jobs:
   testing:
     name: Testing


### PR DESCRIPTION
Potential fix for [https://github.com/flume/enthistory/security/code-scanning/1](https://github.com/flume/enthistory/security/code-scanning/1)

The fix involves adding an explicit `permissions` block to the workflow or individual jobs to define the least privileges required for the tasks. Each job should have its own `permissions` block, or one can be added at the root of the workflow to apply to all jobs. In this case, the workflow consists of three jobs (`testing`, `linting`, and `formatting`), none of which seem to require elevated write permissions. Therefore, a `permissions` block with `contents: read` should be added at the root level for all jobs. This ensures that the `GITHUB_TOKEN` has read-only access to the repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
