### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - "**" # Run on all branches
 
+permissions:
+  contents: read
+
 jobs:
   testing:
     name: Testing


### PR DESCRIPTION
Potential fix for [https://github.com/flume/enthistory/security/code-scanning/2](https://github.com/flume/enthistory/security/code-scanning/2)

To address the issue, add an explicit `permissions` block to the root of the workflow and/or individual jobs. For this workflow:

1. The `testing` job likely only requires `contents: read` because it checks out code, sets up Go, and runs tests.
2. The `linting` job also likely only needs `contents: read` for similar reasons.
3. The `formatting` job performs formatting checks but does not appear to require write permissions either. Hence, `contents: read` is also sufficient.

Add a `permissions` block at the root level to apply to all jobs. If future jobs require differing permissions, individual `permissions` blocks can override the root-level configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
