### PR TITLE
chore: Add JIRA sync workflow

### DIFF
--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -1,0 +1,15 @@
+name: JIRA Sync
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - ready_for_review
+      - converted_to_draft
+      - closed
+
+jobs:
+  jira-sync:
+    uses: flume/github-actions/.github/workflows/jira-sync.yml@main
+    secrets: inherit


### PR DESCRIPTION
Adds the shared JIRA sync workflow from `flume/github-actions`. This automatically syncs PR lifecycle events to JIRA: status transitions (Build/QA/Done) and description sync (PR description → JIRA ticket).