### PR TITLE
fix: add .snyk safety net ignore for goldmark XSS

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -149,6 +149,16 @@ ignore:
           not listed in go.mod and not compiled into any binary.
         expires: 2026-10-09T00:00:00.000Z
         created: 2026-04-09T00:00:00.000Z
+  # --- goldmark XSS vulnerability (transitive ghost dep; not compiled) ---
+  SNYK-GOLANG-GITHUBCOMYUINGOLDMARKRENDERHTML-15838406:
+    - '*':
+        reason: >-
+          CVE-2026-5160 Cross-site Scripting (CWE-79).
+          github.com/yuin/goldmark is a transitive dependency of golang.org/x/tools v0.44.0;
+          not listed in go.mod and not compiled into any binary.
+          `go mod why` confirms: "main module does not need package github.com/yuin/goldmark".
+        expires: 2026-10-15T00:00:00.000Z
+        created: 2026-04-15T00:00:00.000Z
   # --- golang.org/x/crypto vulnerabilities (transitive ghost dep; not in go.mod) ---
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-8747056:
     - '*':


### PR DESCRIPTION
## Summary

- Adds `.snyk` safety-net ignore for goldmark XSS vulnerability (CVE-2026-5160, `SNYK-GOLANG-GITHUBCOMYUINGOLDMARKRENDERHTML-15838406`)
- `github.com/yuin/goldmark@v1.4.13` is a ghost transitive dependency via `golang.org/x/tools@v0.44.0` — not listed in `go.mod` and never compiled into any binary
- `go mod why` confirms: "main module does not need package github.com/yuin/goldmark"
- Consistent with existing safety-net ignores for go-jose and x/crypto

## Context

JIRA FL-29335 (goldmark XSS in `_examples/go.mod`) is still open, while the identical FL-29336 (`go.mod`) is already DONE. Both are ghost deps with no vulnerable code paths. `golang.org/x/tools@v0.44.0` (latest) still requires goldmark v1.4.13 — no upstream fix available yet.

## Verification

- `snyk test --org=flume` passes with 0 vulnerabilities (both `go.mod` and `_examples/go.mod`)
- `go test ./` passes
- `cd _examples && go test ./.` passes

## Test plan

- [x] Snyk scan clean on both modules
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Close FL-29335 in JIRA after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)