### PR TITLE
fix: patch Snyk ghost dependency vulnerabilities

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -24,7 +24,8 @@ ignore:
           No fix available; msgpack v5.4.1 is the latest version.
           Transitive dependency of hashicorp/hcl, ariga.io/atlas, entgo.io/ent,
           zclconf/go-cty, and zclconf/go-cty-yaml. Cannot remove without forking upstream.
-        expires: 2026-07-03T00:00:00.000Z
+          Last verified: 2026-04-22.
+        expires: 2027-01-03T00:00:00.000Z
         created: 2026-04-03T00:00:00.000Z
   SNYK-GOLANG-GITHUBCOMVMIHAILENCOMSGPACK-15702236:
     - '*':
@@ -34,7 +35,8 @@ ignore:
           Transitive dependency of hashicorp/hcl, ariga.io/atlas, entgo.io/ent,
           zclconf/go-cty, and zclconf/go-cty-yaml. Cannot remove without forking upstream.
           Duplicate Snyk entry for same CVE under alternate package path.
-        expires: 2026-07-03T00:00:00.000Z
+          Last verified: 2026-04-22.
+        expires: 2027-01-03T00:00:00.000Z
         created: 2026-04-07T00:00:00.000Z
   # --- OpenTelemetry SDK vulnerability (not imported; transitive ghost dep via grpc) ---
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELSDKRESOURCE-15182758:

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/sosodev/duration v1.4.0 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/zclconf/go-cty v1.18.0 // indirect
+	github.com/zclconf/go-cty v1.18.1 // indirect
 	github.com/zclconf/go-cty-yaml v1.2.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect

--- a/_examples/go.mod
+++ b/_examples/go.mod
@@ -49,3 +49,9 @@ require (
 )
 
 replace github.com/flume/enthistory => ../.
+
+replace github.com/go-jose/go-jose/v4 => github.com/go-jose/go-jose/v4 v4.1.4
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.50.0
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.8.2

--- a/_examples/go.sum
+++ b/_examples/go.sum
@@ -83,8 +83,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/zclconf/go-cty v1.18.0 h1:pJ8+HNI4gFoyRNqVE37wWbJWVw43BZczFo7KUoRczaA=
-github.com/zclconf/go-cty v1.18.0/go.mod h1:qpnV6EDNgC1sns/AleL1fvatHw72j+S+nS+MJ+T2CSg=
+github.com/zclconf/go-cty v1.18.1 h1:yEGE8M4iIZlyKQURZNb2SnEyZlZHUcBCnx6KF81KuwM=
+github.com/zclconf/go-cty v1.18.1/go.mod h1:qpnV6EDNgC1sns/AleL1fvatHw72j+S+nS+MJ+T2CSg=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 github.com/zclconf/go-cty-yaml v1.2.0 h1:GDyL4+e/Qe/S0B7YaecMLbVvAR/Mp21CXMOSiCTOi1M=

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.32 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/zclconf/go-cty v1.18.0 // indirect
+	github.com/zclconf/go-cty v1.18.1 // indirect
 	github.com/zclconf/go-cty-yaml v1.2.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect

--- a/go.mod
+++ b/go.mod
@@ -46,3 +46,9 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260413220744-3e5c5a5a0756 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/go-jose/go-jose/v4 => github.com/go-jose/go-jose/v4 v4.1.4
+
+replace golang.org/x/crypto => golang.org/x/crypto v0.50.0
+
+replace github.com/yuin/goldmark => github.com/yuin/goldmark v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/zclconf/go-cty v1.18.0 h1:pJ8+HNI4gFoyRNqVE37wWbJWVw43BZczFo7KUoRczaA=
-github.com/zclconf/go-cty v1.18.0/go.mod h1:qpnV6EDNgC1sns/AleL1fvatHw72j+S+nS+MJ+T2CSg=
+github.com/zclconf/go-cty v1.18.1 h1:yEGE8M4iIZlyKQURZNb2SnEyZlZHUcBCnx6KF81KuwM=
+github.com/zclconf/go-cty v1.18.1/go.mod h1:qpnV6EDNgC1sns/AleL1fvatHw72j+S+nS+MJ+T2CSg=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 github.com/zclconf/go-cty-yaml v1.2.0 h1:GDyL4+e/Qe/S0B7YaecMLbVvAR/Mp21CXMOSiCTOi1M=


### PR DESCRIPTION
## Summary

- **Replace directives** for three ghost transitive dependencies flagged by Snyk — pins patched versions so Snyk resolves them as fixed:
  - `github.com/go-jose/go-jose/v4`: v4.1.3 → v4.1.4 (CVSS 8.7, Uncaught Exception)
  - `golang.org/x/crypto`: v0.38.0 → v0.50.0 (CVSS 6.9, Resource Allocation + OOB Read)
  - `github.com/yuin/goldmark`: v1.4.13 → v1.8.2 (CVSS 5.1, XSS)
- **Extend `.snyk` msgpack ignores** from 2026-07-03 to 2027-01-03 (no upstream fix available)
- **Upgrade `go-cty`** v1.18.0 → v1.18.1 (patch-level indirect dep bump)

## Context

Snyk reports 6 open vulnerability alerts against `go.mod`. All three high-priority CVEs are **ghost transitive dependencies** — they appear in the Go module graph via parent packages (`grpc`, `hcl/v2`, `x/tools`) but are never imported or compiled into any binary (`go mod why` confirms). The parent packages are all at their latest stable versions, so the transitive deps cannot be upgraded via normal `go get`.

`replace` directives solve this by declaring the patched versions in `go.mod`. As a library module, these directives only apply to this repo's own CI/tests — consumers' builds are unaffected (Go ignores replace directives from dependencies). They should be removed once parent packages release versions that require the patched transitive deps.

## Test plan

- [x] `go test ./` — unit tests pass
- [x] `cd _examples && go test ./.` — integration tests pass
- [x] `make lint` — no regressions (pre-existing SA1029 only)
- [x] `snyk test` — 0 open vulnerabilities locally
- [x] `go mod tidy` — replace directives survive
- [x] `go list -m` — confirms patched versions resolve correctly
- [ ] Verify Snyk web UI re-scans and shows 0 open after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)