### PR TITLE
fix: [FL-29536] add explicit permissions to jira-sync workflow

### DIFF
--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -9,6 +9,9 @@ on:
       - converted_to_draft
       - closed
 
+permissions:
+  contents: read
+
 jobs:
   jira-sync:
     uses: flume/github-actions/.github/workflows/jira-sync.yml@main


### PR DESCRIPTION
## Description

Adds an explicit `permissions` block to the `jira-sync.yml` workflow, restricting the `GITHUB_TOKEN` to `contents: read`. This resolves [CodeQL alert #4](https://github.com/flume/enthistory/security/code-scanning/4) (CWE-275: missing workflow permissions).

## Motivation and Context

Without explicit permissions, the workflow inherits repository/org defaults which may be broader than necessary. The reusable workflow only reads PR event payload data and makes JIRA API calls using repository secrets — it needs no write access to the repo.

Jira ticket: FL-29536

## How Has This Been Tested?

- Verified the reusable workflow at `flume/github-actions/.github/workflows/jira-sync.yml` — it only reads `context.payload.pull_request` (from the event, not the API) and makes external JIRA REST calls using secrets
- No GitHub API write operations are performed with the `GITHUB_TOKEN`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)